### PR TITLE
fix missing dash in `docker-compose` command

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -217,7 +217,7 @@ main() {
   COMPOSE_FILE="dev" #Default the Dev file to be used
 
   # Set up our structure for our re-used commands
-  COMPOSE="docker compose -f docker-compose.yml -f docker-compose.$COMPOSE_FILE.yml"
+  COMPOSE="docker-compose -f docker-compose.yml -f docker-compose.$COMPOSE_FILE.yml"
 
   # Check that an argument is passed
   if [ $# -gt 0 ]; then


### PR DESCRIPTION
First time I've actually tried using this, and not sure if I'm missing something basic (feel free to close if I am!), but... all your commands are currently running `docker compose ...` instead of `docker-compose ...`, so they all fail (for me at least) with errors like 

```
➜ ./node_modules/.bin/spin up                                                                                                                                                         
unknown shorthand flag: 'f' in -f
See 'docker --help'.

...etc
```