### PR TITLE
Feature: Add "down", "build", and ability to override Docker Compose file

### DIFF
--- a/bin/spin
+++ b/bin/spin
@@ -227,11 +227,20 @@ action_version() {
 ################################################
 main() {
   ## Set defaults for our environment
-  COMPOSE_FILE="dev" #Default the Dev file to be used
+
+  # Select environment to be used, 
+  # Allows passing as `ENV` environment variable,
+  # or defaults to `dev`
+  ENV=${ENV:-dev}
+
+  # Export the compose file(s) to be used
+  # Allows overriding with standard `COMPOSE_FILE` environment variable
+  # or defaults to building compound from base and environment files
+  export COMPOSE_FILE=${COMPOSE_FILE:-"docker-compose.yml:docker-compose.$ENV.yml"}
 
   # Set up our structure for our re-used commands
-  COMPOSE="docker compose -f docker-compose.yml -f docker-compose.$COMPOSE_FILE.yml"
-
+  COMPOSE="docker compose"
+ 
   # Check that an argument is passed
   if [ $# -gt 0 ]; then
     # Check the first argument and pass the user to proper action, Only some actions need arguments passed.

--- a/bin/spin
+++ b/bin/spin
@@ -280,7 +280,7 @@ main() {
 }
 
 ################################################
-# Where the script acutally starts
+# Where the script actually starts
 ################################################
 
 setup_color

--- a/bin/spin
+++ b/bin/spin
@@ -231,12 +231,12 @@ main() {
   # Select environment to be used, 
   # Allows passing as `ENV` environment variable,
   # or defaults to `dev`
-  ENV=${ENV:-dev}
+  SPIN_ENV=${SPIN_ENV:-dev}
 
   # Export the compose file(s) to be used
   # Allows overriding with standard `COMPOSE_FILE` environment variable
   # or defaults to building compound from base and environment files
-  export COMPOSE_FILE=${COMPOSE_FILE:-"docker-compose.yml:docker-compose.$ENV.yml"}
+  export COMPOSE_FILE=${COMPOSE_FILE:-"docker-compose.yml:docker-compose.$SPIN_ENV.yml"}
 
   # Set up our structure for our re-used commands
   COMPOSE="docker compose"

--- a/bin/spin
+++ b/bin/spin
@@ -245,8 +245,14 @@ main() {
   if [ $# -gt 0 ]; then
     # Check the first argument and pass the user to proper action, Only some actions need arguments passed.
     case $1 in
+      build)
+        action_build "$@"
+      ;;
       debug)
         action_debug "$@"
+      ;;
+      down)
+        action_down "$@"
       ;;
       exec)
         action_exec "$@"
@@ -265,12 +271,6 @@ main() {
       ;;
       up)
         action_up "$@"
-      ;;
-      down)
-        action_down "$@"
-      ;;
-      build)
-        action_build "$@"
       ;;
       update)
         action_update

--- a/bin/spin
+++ b/bin/spin
@@ -116,6 +116,13 @@ setup_color() {
 ################################################
 # 🏎 ACTIONS: Commands people can run
 ################################################
+action_build() {
+  shift 1
+
+  # Build the containers with `docker-compose`
+  $COMPOSE build "$@"
+}
+
 action_debug(){
   
   print_version
@@ -133,6 +140,13 @@ action_debug(){
   printf "${BOLD}${BLUE}Docker Info:${RESET} \n"
   printf "$(docker info)\n"
   
+}
+
+action_down() {
+  shift 1
+
+  # Bring down the containers with `docker-compose`
+  $COMPOSE down --remove-orphans "$@"
 }
 
 action_exec(){
@@ -188,20 +202,6 @@ action_up() {
   fi
   # Bring up the containers with `docker-compose`
   $COMPOSE up --remove-orphans "$@" 
-}
-
-action_down() {
-  shift 1
-
-  # Bring down the containers with `docker-compose`
-  $COMPOSE down --remove-orphans "$@"
-}
-
-action_build() {
-  shift 1
-
-  # Build the containers with `docker-compose`
-  $COMPOSE build "$@"
 }
 
 action_update() {

--- a/bin/spin
+++ b/bin/spin
@@ -188,7 +188,20 @@ action_up() {
   fi
   # Bring up the containers with `docker-compose`
   $COMPOSE up --remove-orphans "$@" 
+}
 
+action_down() {
+  shift 1
+
+  # Bring down the containers with `docker-compose`
+  $COMPOSE down --remove-orphans "$@"
+}
+
+action_build() {
+  shift 1
+
+  # Build the containers with `docker-compose`
+  $COMPOSE build "$@"
 }
 
 action_update() {
@@ -243,6 +256,12 @@ main() {
       ;;
       up)
         action_up "$@"
+      ;;
+      down)
+        action_down "$@"
+      ;;
+      build)
+        action_build "$@"
       ;;
       update)
         action_update


### PR DESCRIPTION
# Original message by @oldskool73
Me again :)

After using for a bit, PR with a couple of additions I feel were needed to work with our existing stuff (which in the past have done a similar thing with random package scripts).

- Added commands for `down` and `build` as I feel these are basic commands we do quite often. Down in particular seems required, if you can `spin up -d` you need a corresponding way to bring everything back down easily. Build I use a lot during the 'get it all working' phase of writing the application docker files.
- Added the ability to override the default `dev` docker compose file from the environment, by setting `ENV=foo`. For example we'll often also have a `stage` one which we might want to test locally also. Some might want to call it `development` etc.
- Added the ability to use the default `COMPOSE_FILE` if set on the environment already. See https://docs.docker.com/compose/reference/envvars/#compose_file . This could be useful for compatibility if others are already using this as a shortcut to launch different compose file combinations, or if they need to use more than the default base + dev combination offered.

# ToDos added by @jaydrogers 
## 👨‍🔬 Before merging to `dev`
- [X] Standardize code (alphabetize, etc)
- [x] Complete code review by @jaydrogers 
## 🚀 Before merging to `main`
### Update Documentation (https://github.com/serversideup/spin-site/pull/1)
- [x] Add `down` documentation
- [x] Add `build` documentation
- [x] Revisit `up` documentation (make sure it  is up to date)
- [x] Document ability to override the default `dev` docker compose file from the environment
- [x] Document ability to use the default `COMPOSE_FILE` if set on the environment already
- [ ] Develop change log
- [ ] Release 🥳