### PR TITLE
Update 2.prerequisites.md

### DIFF
--- a/docs/content/docs/1.getting-started/2.prerequisites.md
+++ b/docs/content/docs/1.getting-started/2.prerequisites.md
@@ -26,6 +26,7 @@ label: Edit this with `sudo nano /etc/hosts` on Mac/Linux or open as Administrat
 127.0.0.1 otherapp.dev.test
 127.0.0.1 myservice.dev.test
 ```
+```spin up``` will use the alias defined in docker-compose.dev.yml L7 under traefik > aliases. 
 ::
 
 


### PR DESCRIPTION
Respect to the maintainers. 
I got stumped and looked around for the solution. The documentation indicates to use myapp.dev.test as an alias in the local hosts file, but in docker-compose.dev.yml it has laravel.dev.test as the alias the software actually uses. This can cause the user to be stumped bad right out of the gate. There may be a better or different way to fix this, but there it is.