### PR TITLE
Some suggestions for the deploy command

### DIFF
--- a/lib/actions/deploy.sh
+++ b/lib/actions/deploy.sh
@@ -140,7 +140,7 @@ action_deploy() {
         # Bring up a local docker registry
         if [ -z "$(docker ps -q -f name=$spin_registry_name)" ]; then
             echo "${BOLD}${BLUE}🚀 Starting local Docker registry...${RESET}"
-            docker run --rm -d -p $registry_port:5000 -v "$SPIN_CACHE_DIR/registry:/var/lib/registry" --name $spin_registry_name registry:2
+            docker run --rm -d -p "$registry_port:5000" -v "$SPIN_CACHE_DIR/registry:/var/lib/registry" --name $spin_registry_name registry:2
         fi
 
         # Prepare the Ansible run

--- a/lib/actions/deploy.sh
+++ b/lib/actions/deploy.sh
@@ -41,7 +41,7 @@ action_deploy() {
                 if [ -f "$config_file_path" ]; then
                     local config_md5_hash
                     config_md5_hash=$(get_md5_hash "$config_file_path" | awk '{ print $1 }')
-                    config_md5_var="SPIN_$(basename "$config_file_path" | tr '[:lower:]' '[:upper:]' | tr '.' '_')_CONFIG_MD5_HASH"
+                    config_md5_var="SPIN_MD5_HASH_$(basename "$config_file_path" | tr '[:lower:]' '[:upper:]' | tr '.' '_')"
 
                     eval "$config_md5_var=$config_md5_hash"
                     export $config_md5_var


### PR DESCRIPTION
- Read the .env file if there is one. This would make it easier to set certain variables on a per project basis.
- Make reading the configuration files dynamic. This way you don't need a .infrastructure folder if you haven't defined any config key. Only caveat is that it will use the file name to generate the environment variable. So 
```
configs:
  traefik:
    name: 'traefik-${SPIN_TRAEFIK_CONFIG_MD5_HASH}.yml'
    file: ./.infrastructure/conf/traefik/prod/traefik.yml
```
Would become:
```
configs:
  traefik:
    name: 'traefik-${SPIN_TRAEFIK_YML_CONFIG_MD5_HASH}.yml'
    file: ./.infrastructure/conf/traefik/prod/traefik.yml
```

This would also work:
```
configs:
  traefik:
    name: 'traefik-${SPIN_TRAEFIK_YML_CONFIG_MD5_HASH}.yml'
    file: ./.infrastructure/conf/traefik/prod/traefik.yml
  redis:
    name: 'redis-${SPIN_REDIS_CONF_CONFIG_MD5_HASH}.yml'
    file: ./.infrastructure/conf/redis/prod/redis.conf
```

Maybe we could drop the _CONFIG_ part, so it becomes `{SPIN_TRAEFIK_YML_MD5_HASH}`

- Remove the requirement for a Docker image. This would make it easier to run specific docker stacks with only redis or traefik
- Added some additional echo statement before and after setting up the tunnel.