### PR TITLE
add `--user` parameter to `docker run` cmd

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -55,7 +55,7 @@ install_spin_package_to_project() {
   project_dir="$(pwd)/$project_name"
   case "$framework" in
     "php")
-      docker run --rm -v $project_dir:/var/www/html -e "LOG_LEVEL=off" $SPIN_PHP_IMAGE composer --working-dir=/var/www/html/ require serversideup/spin:^2.0@beta --dev
+      docker run --rm --user "${SPIN_USER_ID}:${SPIN_GROUP_ID}" -v $project_dir:/var/www/html -e "LOG_LEVEL=off" $SPIN_PHP_IMAGE composer --working-dir=/var/www/html/ require serversideup/spin:^2.0@beta --dev
       ;;
     "node")
       if [[ -f "$project_dir/package-lock.json" && -f "$project_dir/package.json" ]]; then


### PR DESCRIPTION
When I started a new Laravel project with the current Spin version (v2.0.0-beta5), a file permission error occurred when Spin tried to copy its package files into the project.

![Bildschirmfoto vom 2024-06-11 12-39-51](https://github.com/serversideup/spin/assets/38781482/2f8a9c70-0ded-46b7-9ff6-74a88bafcf59)

I think it occurs because the `--user` parameter is missing on the relating `docker run` command, so I've added it with this patch which has worked for me. There might be other `docker run` commands, where the parameter has to be added. Perhaps, it might be useful to add a wrapper function to call `docker run` with some default parameters.