### PR TITLE
fix: Use absolute path while mounting volumes

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -396,7 +396,7 @@ print_version() {
 }
 
 run_ansible (){
-  ansible_collections_path="./.infrastructure/conf/spin/collections"
+  ansible_collections_path=$(pwd)"/.infrastructure/conf/spin/collections"
   
   # Mount the SSH Agent for macOS systems
   if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
As docker doesn't recognize relative directories, run_ansible was failing with below.
```
docker: Error response from daemon: create ./.infrastructure/conf/spin/collections: "./.infrastructure/conf/spin/collections" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
```
Fixing the same using absolute path