### PR TITLE
Change healthcheck url from /ping to /healthcheck

### DIFF
--- a/templates/laravel/docker-compose.prod.yml
+++ b/templates/laravel/docker-compose.prod.yml
@@ -88,7 +88,7 @@ services:
         - "traefik.http.services.my-php-app.loadbalancer.server.port=8080"
         - "traefik.http.services.my-php-app.loadbalancer.server.scheme=http"
         # Health check
-        - "traefik.http.services.my-php-app.loadbalancer.healthcheck.path=/ping"
+        - "traefik.http.services.my-php-app.loadbalancer.healthcheck.path=/healthcheck"
         - "traefik.http.services.my-php-app.loadbalancer.healthcheck.interval=100ms"
         - "traefik.http.services.my-php-app.loadbalancer.healthcheck.timeout=75ms"
         - "traefik.http.services.my-php-app.loadbalancer.healthcheck.scheme=http"


### PR DESCRIPTION
The healthcheck url was changed recently in the serversideup/docker-php project from /ping to /healthcheck. This caused Traefik to fail the healthcheck resulting in the service being unavailable. 

This pull request fixes this in the docker-compose.prod.yml file.