### PR TITLE
Improve --local function

### DIFF
--- a/docs/content/docs/3.project-templates/99.create-your-own-template.md
+++ b/docs/content/docs/3.project-templates/99.create-your-own-template.md
@@ -211,12 +211,14 @@ spin new serversideup/spin-template-laravel-basic --branch test-branch
 ```
 ::
 
+The above command will pull the `test-branch` from the `https://github.com/serversideup/spin-template-laravel-basic` repository and use that version of the template.
+
 ::code-panel
 ---
 label: Test locally
 ---
 ```bash
-spin new serversideup/spin-template-laravel-basic --local /path/to/your/template
+spin new --local /path/to/your/template
 ```
 ::
 

--- a/lib/actions/init.sh
+++ b/lib/actions/init.sh
@@ -64,7 +64,9 @@ action_init() {
 
     if [ -z "$SPIN_USER_TODOS" ]; then
         echo "${BOLD}${GREEN}🚀 Your project is now ready for \"spin up\"!${RESET}"
-        echo "${BOLD}${YELLOW}👉 Learn how to use your template at https://github.com/$TEMPLATE_REPOSITORY${RESET}"
+        if [[ -z "$TEMPLATE_REPOSITORY" ]]; then
+            echo "${BOLD}${YELLOW}👉 Learn how to use your template at https://github.com/$TEMPLATE_REPOSITORY${RESET}"
+        fi
     else
         echo "${BOLD}${GREEN}🚀 Installation complete!${RESET}"
         echo "${BOLD}${BLUE} Some packages can't be installed automatically."


### PR DESCRIPTION
This cleans up the `--local` syntax from:

```bash
spin new serversideup/spin-template-laravel-basic --local /path/to/your/template
```

To:

```bash
spin new --local /path/to/your/template
```