### PR TITLE
Support deploying without a Dockerfile

### DIFF
--- a/lib/actions/deploy.sh
+++ b/lib/actions/deploy.sh
@@ -192,7 +192,10 @@ action_deploy() {
     }
 
     # Check if any Dockerfiles exist
+    set +e
     dockerfiles=$(ls Dockerfile* 2>/dev/null)
+    set -e
+    
     if [[ -n "$dockerfiles" ]]; then
         # Bring up a local docker registry
         if [ -z "$(docker ps -q -f name=$spin_registry_name)" ]; then
@@ -225,8 +228,7 @@ action_deploy() {
             fi
         done
     else
-        echo "${BOLD}${RED} No Dockerfiles found in the directory. Be sure you're running this command from the project root.${RESET}"
-        exit 1
+        echo "${BOLD}${BLUE}🐳 No Dockerfiles found in the directory. Skipping building image...${RESET}"
     fi
 
     # Prepare SSH connection


### PR DESCRIPTION
It would be nice to be able to deploy spin projects that do not contain a Dockerfile. For example I have deployed a spin project with just containing a traefik service, allowing to deploy multiple web projects on a single server that use the same Traefik instance.

The `+e`/`-e` is needed to make sure the deploy script doesnt exit when no dockerfile is found. This happens on Mac when ls is not returning any results. There might be a better way around this, I'm open for alternatives.