### PR TITLE
Improve "spin prune" and optimize SSH experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ All of our software is free an open to the world. None of this can be brought to
 <p align="center"><a href="https://github.com/sponsors/serversideup"><img src="https://521public.s3.amazonaws.com/serversideup/sponsors/sponsor-box.png" alt="Sponsors"></a></p>
 
 #### Individual Supporters
-<!-- supporters --><a href="https://github.com/GeekDougle"><img src="https://github.com/GeekDougle.png" width="40px" alt="GeekDougle" /></a>&nbsp;&nbsp;<a href="https://github.com/JQuilty"><img src="https://github.com/JQuilty.png" width="40px" alt="JQuilty" /></a>&nbsp;&nbsp;<a href="https://github.com/pferreirafabricio"><img src="https://github.com/pferreirafabricio.png" width="40px" alt="pferreirafabricio" /></a>&nbsp;&nbsp;<!-- supporters -->
+<!-- supporters --><a href="https://github.com/GeekDougle"><img src="https://github.com/GeekDougle.png" width="40px" alt="GeekDougle" /></a>&nbsp;&nbsp;<a href="https://github.com/JQuilty"><img src="https://github.com/JQuilty.png" width="40px" alt="JQuilty" /></a>&nbsp;&nbsp;<a href="https://github.com/pferreirafabricio"><img src="https://github.com/pferreirafabricio.png" width="40px" alt="pferreirafabricio" /></a>&nbsp;&nbsp;<a href="https://github.com/MaltMethodDev"><img src="https://github.com/MaltMethodDev.png" width="40px" alt="MaltMethodDev" /></a>&nbsp;&nbsp;<!-- supporters -->
 
 ## About Us
 We're [Dan](https://twitter.com/danpastori) and [Jay](https://twitter.com/jaydrogers) - a two person team with a passion for open source products. We created [Server Side Up](https://serversideup.net) to help share what we learn.

--- a/lib/actions/prune.sh
+++ b/lib/actions/prune.sh
@@ -3,6 +3,24 @@ action_prune(){
   echo "${BOLD}${YELLOW}🚨 You're about to delete some data.${RESET}"
   docker system prune --all $@
   echo "${BOLD}${GREEN}✅ Docker cache cleared.${RESET}"
-  rm -rf $SPIN_CACHE_DIR/.spin*
-  echo "${BOLD}${GREEN}✅ Spin cache cleared.${RESET}"
+
+  if [ -z "$SPIN_CACHE_DIR" ]; then
+    echo "Error: SPIN_CACHE_DIR is not set"
+    exit 1
+  fi
+
+  if compgen -G "$SPIN_CACHE_DIR/.spin*" > /dev/null; then
+    rm -rf "$SPIN_CACHE_DIR"/.spin*
+    echo "${BOLD}${GREEN}✅ Spin update cache cleared.${RESET}"
+  fi
+
+  if [ -d "$SPIN_CACHE_DIR/collections/" ]; then
+    rm -rf $SPIN_CACHE_DIR/collections/
+    echo "${BOLD}${GREEN}✅ Spin Ansible Collections cache cleared.${RESET}"
+  fi
+
+  if [ -d "$SPIN_CACHE_DIR/registry/" ]; then
+    rm -rf $SPIN_CACHE_DIR/registry/
+    echo "${BOLD}${GREEN}✅ Spin Docker Registry cache cleared.${RESET}"
+  fi  
 }

--- a/lib/actions/prune.sh
+++ b/lib/actions/prune.sh
@@ -4,21 +4,25 @@ action_prune(){
   docker system prune --all $@
   echo "${BOLD}${GREEN}✅ Docker cache cleared.${RESET}"
 
+  # Validate SPIN_CACHE_DIR variable is set
   if [ -z "$SPIN_CACHE_DIR" ]; then
     echo "Error: SPIN_CACHE_DIR is not set"
     exit 1
   fi
 
+  # Remove spin cache
   if compgen -G "$SPIN_CACHE_DIR/.spin*" > /dev/null; then
     rm -rf "$SPIN_CACHE_DIR"/.spin*
     echo "${BOLD}${GREEN}✅ Spin update cache cleared.${RESET}"
   fi
 
+  # Remove ansible collections cache
   if [ -d "$SPIN_CACHE_DIR/collections/" ]; then
     rm -rf $SPIN_CACHE_DIR/collections/
     echo "${BOLD}${GREEN}✅ Spin Ansible Collections cache cleared.${RESET}"
   fi
 
+  # Remove docker registry cache
   if [ -d "$SPIN_CACHE_DIR/registry/" ]; then
     rm -rf $SPIN_CACHE_DIR/registry/
     echo "${BOLD}${GREEN}✅ Spin Docker Registry cache cleared.${RESET}"

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -946,10 +946,15 @@ run_ansible() {
   # Create the collections directory if it doesn't exist
   mkdir -p "$ansible_collections_path"
 
+  # Create the known_hosts file if it doesn't exist
+  if [[ ! -f "$HOME/.ssh/known_hosts" ]]; then
+    touch "$HOME/.ssh/known_hosts"
+  fi
+
   while [[ "$#" -gt 0 ]]; do
     case "$1" in
       --allow-ssh)
-        additional_docker_args+=("-v" "$HOME/.ssh/:/ssh/" "-v" "$ansible_collections_path:/etc/ansible/collections")
+        additional_docker_args+=("-v" "$HOME/.ssh/:/ssh/:ro" "-v" "$HOME/.ssh/known_hosts:/ssh/known_hosts:rw" "-v" "$ansible_collections_path:/etc/ansible/collections")
         # Mount the SSH Agent for macOS and Linux (including WSL2) systems
         if [ -n "$SSH_AUTH_SOCK" ]; then
             case "$(uname -s)" in


### PR DESCRIPTION
# What this PR does
This PR will address the following issues:

## `spin prune` is not clearing registry or Ansible collections cache
We found that some cache files were being removed, but not everything. This PR ensures:
- Spin Cache
- Ansible Collections Cache
- Local Docker Registry cache

## The local registry is no longer running as root
When users were running `spin deploy`, it was starting the registry as the default `root` user within the container. We've now added the `--user` flag to set the registry to to run as the current running user id and group id. This improves experiences for running everything as an unprivileged user.

## Add support for SSH_AUTH_SOCK on Linux
We added the ability for the SSH Auth Socket to be set and work with Linux and WSL2 hosts. 

# Next steps
Before merging, I need to do the following:
- [x] Run some final tests that WSL2 is deploying correctly
- [x] Users should be able to run a `spin prune` and then a `spin deploy` multiple times without permission issues
- [x] Test that SSH keys with passwords are working with WSL2 & macOS