### PR TITLE
Update Docker Compose file references and commands

### DIFF
--- a/docs/content/docs/2.getting-started/1.how-spin-works.md
+++ b/docs/content/docs/2.getting-started/1.how-spin-works.md
@@ -12,7 +12,7 @@ Spin is a collection of proven open source technologies delivered to you in a li
 ::
 
 ## Spin stays out of your way
-Spin is designed to be flexible and gives you the power to choose what you'd like Spin to help you with. For example, if you want to use your current PaaS provider for production deployments, but you just want to use Spin for local development, you can easily do that without Spin getting in the way. Simply delete the `docker-compose.prod.yml` file and you won't need to do anything else.
+Spin is designed to be flexible and gives you the power to choose what you'd like Spin to help you with. For example, if you want to use your current PaaS provider for production deployments, but you just want to use Spin for local development, you can easily do that without Spin getting in the way. Simply delete the `compose.prod.yaml` file and you won't need to do anything else.
 
 ## What Spin Is Built On Top Of
 ![Spin Diagram](/images/docs/whats-spin/spin-diagram.png)
@@ -54,7 +54,7 @@ For some advanced users that are running massive server farms, you might want to
 The good news is **you don't need to use Spin everywhere.** Spin is a *structure* just as much as it is a tool. Spin is designed to be there when you need it and get out of your way when you don't.
 
 ## Important concepts
-Spin's flexibility comes from embracing the [Docker Compose Overrides (aka Docker Compose Extends)](https://docs.docker.com/compose/multiple-compose-files/extends/) structure. We use a "base" `docker-compose.yml` file, then choose a file based on the environment.
+Spin's flexibility comes from embracing the [Docker Compose Overrides (aka Docker Compose Extends)](https://docs.docker.com/compose/multiple-compose-files/extends/) structure. We use a "base" `compose.yaml` file, then choose a file based on the environment.
 
 Here is a visual of what the file structure looks like:
 
@@ -67,7 +67,7 @@ Docker natively selecting these files, but it is a huge pain to type out each ti
 label: What we would have to type with Docker Compose 😅
 ---
 ```bash
-docker compose pull && docker compose -f docker-compose.yml -f docker-compose.dev.yml up
+docker compose pull && docker compose -f compose.yaml -f compose.dev.yaml up
 ```
 ::
 

--- a/docs/content/docs/4.server-configuration/2.server-configuration-basics.md
+++ b/docs/content/docs/4.server-configuration/2.server-configuration-basics.md
@@ -14,7 +14,7 @@ Spin ensures your application can be 100% replicated from development to product
 ## 👉 Important: Spin doesn't need to manage your servers if you don't want it to
 It's kind of weird to start a document to talk about how NOT to use a feature, but we want to show the flexibility that Spin gives you. If you're satisfied with your current hosting provider, you don't need to use Spin to manage your servers. You can easily configure your PaaS to use the same Dockerfiles that you're using in development with Spin. You'll just need to reference your PaaS's own documentation on how to do this.
 
-All you need to do is delete the `.spin.yml` and any `docker-compose.*.yml` files that you don't want and `spin up` will still work perfectly fine.
+All you need to do is delete the `.spin.yml` and any `compose.*.yml` files that you don't want and `spin up` will still work perfectly fine.
 
 If you prefer to not have any vendor lock-in from a PaaS provider and you're interested in the full control of your own servers, keep reading! Spin will give you the power of a PaaS without the restriction of running your application on a specific platform.
 

--- a/docs/content/docs/7.server-access/2.troubleshooting-your-application.md
+++ b/docs/content/docs/7.server-access/2.troubleshooting-your-application.md
@@ -130,7 +130,7 @@ Only use debug modes if you're actively troubleshooting an issue. Debug mode wil
 
 ::code-panel
 ---
-label: Set the LOG_OUTPUT_LEVEL docker-compose.prod.yml file
+label: Set the LOG_OUTPUT_LEVEL compose.prod.yaml file
 ---
 ```yml
 services:

--- a/docs/content/docs/7.server-access/3.updating-your-server.md
+++ b/docs/content/docs/7.server-access/3.updating-your-server.md
@@ -22,7 +22,7 @@ Running an out of date server stack can lead to security vulnerabilities and per
 ![Spin Maintain Command](/images/docs/whats-spin/spin-maintain.png)
 
 ### Application Stack Updates
-What we mean by application stack updates are things like Redis, Postgres, Node, PHP, etc. These are things you'll want to look at in your `docker-compose.*.yml`, `composer.json`, `package.json`, etc. Whenever you make a change, it will be version controlled so you can easily test and revert if needed.
+What we mean by application stack updates are things like Redis, Postgres, Node, PHP, etc. These are things you'll want to look at in your `compose.*.yaml`, `composer.json`, `package.json`, etc. Whenever you make a change, it will be version controlled so you can easily test and revert if needed.
 
 ### Server Updates
 Server updates are things like the underlying operating system, Docker, etc. It's important to keep these packages up to date as well. Thankfully Spin includes the [`spin maintain`](/docs/command-reference/maintain) command which will take care of the heavy lifting for you.

--- a/docs/content/docs/8.advanced/3.adding-other-services.md
+++ b/docs/content/docs/8.advanced/3.adding-other-services.md
@@ -21,7 +21,7 @@ We make a few assumptions in our examples below:
 
 ::code-panel
 ---
-label: "Example: docker-compose.yml"
+label: "Example: compose.yaml"
 ---
 ```yml
 services:
@@ -32,7 +32,7 @@ services:
 
 ::code-panel
 ---
-label: "Example: docker-compose.dev.yml"
+label: "Example: compose.dev.yaml"
 ---
 ```yml
 services:
@@ -58,7 +58,7 @@ networks:
 
 ::code-panel
 ---
-label: "Example: docker-compose.yml"
+label: "Example: compose.yaml"
 ---
 ```yml
 services:
@@ -71,7 +71,7 @@ services:
 
 ::code-panel
 ---
-label: "Example: docker-compose.dev.yml"
+label: "Example: compose.dev.yaml"
 ---
 ```yml
 services:
@@ -92,7 +92,7 @@ networks:
 
 ::code-panel
 ---
-label: "Example: docker-compose.yml"
+label: "Example: compose.yaml"
 ---
 ```yml
 services:
@@ -103,7 +103,7 @@ services:
 
 ::code-panel
 ---
-label: "Example: docker-compose.dev.yml"
+label: "Example: compose.dev.yaml"
 ---
 ```yml
 services:
@@ -129,7 +129,7 @@ networks:
 
 ::code-panel
 ---
-label: "Example: docker-compose.yml"
+label: "Example: compose.yaml"
 ---
 ```yml
 services:
@@ -142,7 +142,7 @@ services:
 
 ::code-panel
 ---
-label: "Example: docker-compose.dev.yml"
+label: "Example: compose.dev.yaml"
 ---
 ```yml
 services:
@@ -192,7 +192,7 @@ Notice how this project is using `build` instead of just calling an image direct
 
 ::code-panel
 ---
-label: "Example: docker-compose.yml"
+label: "Example: compose.yaml"
 ---
 ```yml
 services:
@@ -205,7 +205,7 @@ services:
 
 ::code-panel
 ---
-label: "Example: docker-compose.dev.yml"
+label: "Example: compose.dev.yaml"
 ---
 ```yml
 services:
@@ -255,7 +255,7 @@ COPY --chown=www-data:www-data . /var/www/html
 ::
 
 #### Using with Traefik
-The docker-compose.yml examples above exposes the HTTP server on port 80. If you use something like Traefik, you would replace the ports with labels, like this:
+The compose.yaml examples above exposes the HTTP server on port 80. If you use something like Traefik, you would replace the ports with labels, like this:
 
 ::code-panel
 ---
@@ -275,7 +275,7 @@ label: "Laravel Traefik Labels Example"
 
 ::code-panel
 ---
-label: "Example: docker-compose.yml"
+label: "Example: compose.yaml"
 ---
 ```yml
 services:
@@ -286,7 +286,7 @@ services:
 
 ::code-panel
 ---
-label: "Example: docker-compose.dev.yml"
+label: "Example: compose.dev.yaml"
 ---
 ```yml
 services:
@@ -308,7 +308,7 @@ networks:
 See the [Soketi documentation](https://docs.soketi.app/getting-started/installation/docker) for selecting the correct version.
 ::code-panel
 ---
-label: "Example: docker-compose.yml"
+label: "Example: compose.yaml"
 ---
 ```yml
 services:
@@ -319,7 +319,7 @@ services:
 
 ::code-panel
 ---
-label: "Example: docker-compose.dev.yml"
+label: "Example: compose.dev.yaml"
 ---
 ```yml
 services:
@@ -337,7 +337,7 @@ networks:
 ::
 
 #### Using with Traefik
-The docker-compose.yml examples above exposes the HTTP server on port 80. If you use something like Traefik, you would replace the ports with labels, like this:
+The compose.yaml examples above exposes the HTTP server on port 80. If you use something like Traefik, you would replace the ports with labels, like this:
 
 ::code-panel
 ---
@@ -359,7 +359,7 @@ Traefik is a reverse proxy and is great for terminating SSL for any service that
 
 ::code-panel
 ---
-label: "Example: docker-compose.yml"
+label: "Example: compose.yaml"
 ---
 ```yml
 services:
@@ -370,7 +370,7 @@ services:
 
 ::code-panel
 ---
-label: "Example: docker-compose.dev.yml"
+label: "Example: compose.dev.yaml"
 ---
 ```yml
   traefik:

--- a/docs/content/docs/8.advanced/99.create-your-own-template.md
+++ b/docs/content/docs/8.advanced/99.create-your-own-template.md
@@ -57,9 +57,9 @@ Be sure to replace the values with your own information and completely fill out 
 ### template/ directory
 This is where you place your template files for Docker Compose and Docker Swarm. Be sure to follow the structure of:
 
-- Base Docker Compose File: `docker-compose.yml`
-- Development Docker Compose File: `docker-compose.dev.yml`
-- Production Docker Compose File: `docker-compose.prod.yml`
+- Base Docker Compose File: `compose.yaml`
+- Development Docker Compose File: `compose.dev.yaml`
+- Production Docker Compose File: `compose.prod.yaml`
 
 You can also put any configurations under `.infrastructure/conf/` if you need to provide any default configurations for your project.
 

--- a/docs/content/docs/9.command-reference/build.md
+++ b/docs/content/docs/9.command-reference/build.md
@@ -7,7 +7,7 @@ canonical: https://serversideup.net/open-source/spin/docs/command-reference/buil
 ---
 # spin build
 ::lead-p
-Trigger a build of your docker-compose files.
+Trigger a build of your compose files.
 ::
 
 ## Usage
@@ -20,4 +20,4 @@ spin build [OPTIONS]
 ```
 ::
 ## Official Documentation & Additional Options
-This command is a shortcut for [`docker-compose build`](https://docs.docker.com/compose/reference/build/) and can accept additional options that you pass to it.
+This command is a shortcut for [`docker compose build`](https://docs.docker.com/compose/reference/build/) and can accept additional options that you pass to it.

--- a/docs/content/docs/9.command-reference/deploy.md
+++ b/docs/content/docs/9.command-reference/deploy.md
@@ -65,7 +65,7 @@ This comprehensive process ensures that your application is built, pushed, and d
 The following options are available to set when running this command.
 | Option | Short | Default | Description |
 | --- | --- | --- | --- |
-| `--compose-file` | `-c` | By default, we look for two files `docker-compose.yml, docker-compose.prod.yml` | The name of the compose files. You can provide many of these options to combine many files. |
+| `--compose-file` | `-c` | By default, we look for two files `compose.yaml, compose.prod.yaml` | The name of the compose files. You can provide many of these options to combine many files. |
 | `--port` | `-p` | `22` | The port to SSH into the server with. |
 | `--upgrade` | `-U` | `false` | Force the upgrade of the Ansible collection. |
 | `--user` | `-u` | The username of your HOST machine (run `whoami` in a new terminal) | The user to SSH into the server with. |

--- a/docs/content/docs/9.command-reference/logs.md
+++ b/docs/content/docs/9.command-reference/logs.md
@@ -21,4 +21,4 @@ spin logs [OPTIONS]
 ::
 
 ## Official Documentation & Additional Options
-This command is a shortcut for [`docker-compose logs`](https://docs.docker.com/compose/reference/logs/) and can accept additional options that you pass to it.
+This command is a shortcut for [`docker compose logs`](https://docs.docker.com/compose/reference/logs/) and can accept additional options that you pass to it.

--- a/docs/content/docs/9.command-reference/pull.md
+++ b/docs/content/docs/9.command-reference/pull.md
@@ -20,4 +20,4 @@ spin pull [OPTIONS]
 ```
 ::
 ## Official Documentation & Additional Options
-This command is a shortcut for [`docker-compose pull`](https://docs.docker.com/engine/reference/commandline/compose_pull/) and can accept additional options that you pass to it.
+This command is a shortcut for [`docker compose pull`](https://docs.docker.com/engine/reference/commandline/compose_pull/) and can accept additional options that you pass to it.

--- a/docs/content/docs/9.command-reference/run.md
+++ b/docs/content/docs/9.command-reference/run.md
@@ -35,7 +35,7 @@ spin run php composer install
 - `--force-pull`: Pull Docker Compose images, regardless of cache settings.
 
 ### Official Docker Options
-This command is a shortcut for [`docker-compose run`](https://docs.docker.com/compose/reference/run/) and can accept additional options that you pass to it.
+This command is a shortcut for [`docker compose run`](https://docs.docker.com/compose/reference/run/) and can accept additional options that you pass to it.
 
 ## Special notes
 * This command specifically ignores running container dependencies

--- a/docs/content/docs/9.command-reference/up.md
+++ b/docs/content/docs/9.command-reference/up.md
@@ -7,7 +7,7 @@ canonical: https://serversideup.net/open-source/spin/docs/command-reference/up
 ---
 # spin up
 ::lead-p
-Bring up all containers defined in `docker-compose.yml` and `docker-compose.$SPIN_ENV.yml` (`$SPIN_ENV` defaults to `dev`).
+Bring up all containers defined in `compose.yaml` and `compose.$SPIN_ENV.yaml` (`$SPIN_ENV` defaults to `dev`).
 ::
 
 ## Usage
@@ -33,7 +33,7 @@ spin up --build
 ```
 ::
 
-You can add options at the end of the command (like the `--build` shown above. The above command will bring up your containers, but then also force a new build (if you have builds configured in your "docker-compose.dev.yml" file).
+You can add options at the end of the command (like the `--build` shown above. The above command will bring up your containers, but then also force a new build (if you have builds configured in your "compose.dev.yaml" file).
 
 ## Defaults
 The `spin up` command defaults to running:
@@ -42,7 +42,7 @@ The `spin up` command defaults to running:
 label: Command default
 ---
 ```bash
-COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml docker compose up
+COMPOSE_FILE=compose.yaml:compose.dev.yaml docker compose up
 ```
 ::
 
@@ -57,7 +57,7 @@ This command is a shortcut for [`docker compose up`](https://docs.docker.com/com
 
 
 ## Special notes
-* Make sure to have a `docker-compose.yml` and **by default** a `docker-compose.dev.yml` in your project before running
+* Make sure to have a `compose.yaml` and **by default** a `compose.dev.yaml` in your project before running
 * Spin will automatically pull image updates (only if the machine is connected to the Internet)
 * Spin will remove any orphan containers
 
@@ -69,16 +69,16 @@ label: Example project root
 ---
 ```
 .
-├── docker-compose.ci.yml
-├── docker-compose.production.yml
-├── docker-compose.staging.yml
-├── docker-compose.testing.yml
-└── docker-compose.yml
+├── compose.ci.yaml
+├── compose.production.yaml
+├── compose.staging.yaml
+├── compose.testing.yaml
+└── compose.yaml
 ```
 ::
 
 
-By default, Spin uses `docker-compose.yml` and `docker-compose.dev.yml`.
+By default, Spin uses `compose.yaml` and `compose.dev.yaml`.
 
 If you want to change that, you just need to set `$SPIN_ENV`:
 ::code-panel
@@ -98,6 +98,6 @@ This will essentially run:
 label: Above command will execute this below
 ---
 ```bash
-COMPOSE_FILE=docker-compose.yml:docker-compose.testing.yml docker compose up
+COMPOSE_FILE=compose.yaml:compose.testing.yaml docker compose up
 ```
 ::

--- a/lib/actions/build.sh
+++ b/lib/actions/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 action_build() {
-  # Build the containers with `docker-compose`
+  # Build the containers with `docker compose`
   $COMPOSE_CMD build "$@"
 }

--- a/lib/actions/deploy.sh
+++ b/lib/actions/deploy.sh
@@ -34,12 +34,32 @@ deploy_docker_stack() {
 
     # Set default compose files if none were provided
     if [[ ${#compose_files[@]} -eq 0 ]]; then
-        compose_files=("docker-compose.yml" "docker-compose.prod.yml")
+        # Check for compose.yaml first, then docker-compose.yml
+        if [[ -f "compose.yaml" ]]; then
+            compose_files+=("compose.yaml")
+        elif [[ -f "docker-compose.yml" ]]; then
+            compose_files+=("docker-compose.yml")
+        else
+            echo "${BOLD}${RED}❌Error: Neither compose.yaml nor docker-compose.yml found in the current directory.${RESET}"
+            exit 1
+        fi
+
+        # Check for production override files
+        if [[ -f "compose.prod.yaml" ]]; then
+            compose_files+=("compose.prod.yaml")
+        elif [[ -f "docker-compose.prod.yml" ]]; then
+            compose_files+=("docker-compose.prod.yml")
+        fi
     fi
 
     # Build the compose arguments
     for compose_file in "${compose_files[@]}"; do
         if [[ -n "$compose_file" ]]; then
+            # Check if the file exists
+            if [[ ! -f "$compose_file" ]]; then
+                echo "${BOLD}${RED}❌Error: Compose file '$compose_file' not found.${RESET}"
+                exit 1
+            fi
             # Compute MD5 hashes if necessary
             generate_md5_hashes "$compose_file"
             compose_args+=("--compose-file" "$compose_file")


### PR DESCRIPTION
Docker documentation now recommends to use compose.yaml as name for "docker compose" files. See link below.

I think v3 is a good time. That's why I made the changes on v3 only.

I added backwards compatibility with old names, maybe it would be better to add deprecated message when running spin commands?

https://docs.docker.com/compose/intro/compose-application-model/

I can create a pull request for other repositories that expect the name "docker-compose.*.yml", I just need a list of repositories :) (like spin-pro, etc)