### PR TITLE
Add Laravel Boost support

### DIFF
--- a/bin/spin-mcp-wait.sh
+++ b/bin/spin-mcp-wait.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# MCP stdio bridge for Spin + Laravel Boost.
+#
+# Solves two problems when running Boost's MCP server inside Docker:
+# 1. Cursor/IDEs start MCP servers on launch — Docker may not be ready yet.
+#    This script retries until the container is available.
+# 2. Docker outputs startup noise (ANSI codes, container messages) that
+#    corrupts the JSON-RPC stdio protocol. This script filters stdout to
+#    pass only JSON-RPC messages.
+#
+# Usage (in .env):
+#   BOOST_PHP_EXECUTABLE_PATH="./vendor/bin/spin-mcp-wait.sh ./vendor/bin/spin run -T php php"
+#
+# This script is ONLY for MCP server startup. For all other commands, use
+# spin directly: spin run php composer install
+
+set -euo pipefail
+
+is_mcp=0
+for arg in "$@"; do
+    [ "$arg" = "boost:mcp" ] && is_mcp=1 && break
+done
+
+if [ "$is_mcp" -eq 0 ]; then
+    echo "Error: spin-mcp-wait.sh is only for starting the MCP server." >&2
+    echo "Use 'spin' directly instead. Example: spin run php composer install" >&2
+    exit 1
+fi
+
+MAX_RETRIES=${SPIN_MCP_MAX_RETRIES:-60}
+SLEEP_SECONDS=${SPIN_MCP_RETRY_INTERVAL:-5}
+attempt=0
+
+while [ $attempt -lt $MAX_RETRIES ]; do
+    "$@" 2>/dev/null | grep --line-buffered '^{'
+    exit_code="${PIPESTATUS[0]}"
+
+    [ "$exit_code" -eq 0 ] && exit 0
+    [ "$exit_code" -gt 128 ] && exit "$exit_code"
+
+    attempt=$((attempt + 1))
+    echo "spin-mcp-wait: attempt $attempt/$MAX_RETRIES failed (exit $exit_code), retrying in ${SLEEP_SECONDS}s..." >&2
+    sleep "$SLEEP_SECONDS"
+done
+
+echo "spin-mcp-wait: gave up after $MAX_RETRIES attempts." >&2
+echo "spin-mcp-wait: Is Docker Desktop running?" >&2
+exit 1

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "serversideup/spin",
     "description": "Replicate your production environment locally using Docker. Just run \"spin up\". It's really that easy.",
     "bin": [
-        "bin/spin"
+        "bin/spin",
+        "bin/spin-mcp-wait.sh"
       ],
     "authors": [
         {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "homepage": "https://github.com/serversideup/spin#readme",
   "bin": {
-    "spin": "./bin/spin"
+    "spin": "./bin/spin",
+    "spin-mcp-wait.sh": "./bin/spin-mcp-wait.sh"
   }
 }

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -26,6 +26,26 @@ Spin is a lightweight CLI that wraps Docker Compose (development) and Docker Swa
 
 For tasks involving Docker Compose configuration, Dockerfile changes, `serversideup/php` image settings, adding Laravel services (databases, queues, Horizon, Reverb), server provisioning, deployment, or troubleshooting containerized environments — activate the **spin-laravel-development** skill.
 
+## Laravel Boost MCP setup
+
+Since Spin runs PHP inside Docker (not on the host), Laravel Boost needs special configuration to start its MCP server. Spin ships `spin-mcp-wait.sh` which retries until Docker is ready and filters stdout for clean JSON-RPC communication.
+
+Add these to your `.env` file:
+
+```
+BOOST_PHP_EXECUTABLE_PATH="./vendor/bin/spin-mcp-wait.sh ./vendor/bin/spin run -T php php"
+BOOST_COMPOSER_EXECUTABLE_PATH="./vendor/bin/spin run php composer"
+BOOST_NPM_EXECUTABLE_PATH="./vendor/bin/spin run node npm"
+```
+
+Then run:
+
+```
+spin run php php artisan boost:install
+```
+
+**IMPORTANT:** `spin-mcp-wait.sh` is exclusively for MCP server startup. NEVER use it to run commands. Always use `spin run` or `spin exec` for running commands (e.g., `spin run php composer install`).
+
 ## Templates
 
 - **Basic** (`spin new laravel`): Free open source template — <https://github.com/serversideup/spin-template-laravel-basic>

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,0 +1,42 @@
+# Spin — Docker Workflow for Laravel
+
+Spin is a lightweight CLI that wraps Docker Compose (development) and Docker Swarm (production) so you can replicate any environment on any machine.
+
+## Key facts
+
+- Spin follows Docker Compose syntax exactly — `spin up` runs `docker compose up`, `spin run` runs `docker compose run`, etc.
+- Projects use a **Docker Compose overrides** pattern: a base `docker-compose.yml` merged with `docker-compose.dev.yml` (local) or `docker-compose.prod.yml` (production).
+- Laravel projects use `serversideup/php` Docker images (fpm-nginx, fpm-apache, frankenphp, cli).
+- The `.infrastructure/` folder stores configuration files (`conf/`) and gitignored volume data (`volume_data/`).
+- `SPIN_ENV` defaults to `dev`. Running `spin up` uses `docker-compose.yml` + `docker-compose.dev.yml`.
+- In Docker, services connect via container name as hostname (`DB_HOST=mysql`, `REDIS_HOST=redis`), not `localhost`.
+
+## Essential commands
+
+| Command | Purpose |
+|---------|---------|
+| `spin up` | Start development environment (foreground) |
+| `spin up --build` | Start and rebuild containers (recommended default if custom Dockerfile is used) |
+| `spin run <service> <cmd>` | Run a one-off command in a new container |
+| `spin exec <service> <cmd>` | Run a command in a running container |
+| `spin deploy <env>` | Deploy to a provisioned server |
+| `spin provision` | Provision and configure servers |
+
+## When to activate the full skill
+
+For tasks involving Docker Compose configuration, Dockerfile changes, `serversideup/php` image settings, adding Laravel services (databases, queues, Horizon, Reverb), server provisioning, deployment, or troubleshooting containerized environments — activate the **spin-laravel-development** skill.
+
+## Templates
+
+- **Basic** (`spin new laravel`): Free open source template — <https://github.com/serversideup/spin-template-laravel-basic>
+- **Pro** (`spin new laravel-pro`): Premium template with pre-configured services (Horizon, Reverb, databases, Vite, Mailpit, etc.) — <https://getspin.pro>
+
+## Resources
+
+- Spin docs: <https://serversideup.net/open-source/spin/docs>
+- Spin docs (LLM-friendly): <https://serversideup.net/open-source/spin/llms.txt>
+- serversideup/php docs: <https://serversideup.net/open-source/docker-php/docs>
+- serversideup/php docs (LLM-friendly): <https://serversideup.net/open-source/docker-php/llms.txt>
+- serversideup/php full docs (LLM-friendly): <https://serversideup.net/open-source/docker-php/llms-full.txt>
+- serversideup/php environment variable reference: <https://serversideup.net/open-source/docker-php/docs/reference/environment-variable-specification>
+- Spin Pro docs: <https://getspin.pro/docs>

--- a/resources/boost/skills/spin-laravel-development/COMMANDS.md
+++ b/resources/boost/skills/spin-laravel-development/COMMANDS.md
@@ -1,0 +1,332 @@
+# Spin Command Reference
+
+## Table of contents
+
+- [Development commands](#development-commands)
+- [Project setup commands](#project-setup-commands)
+- [Deployment and infrastructure commands](#deployment-and-infrastructure-commands)
+- [Utility commands](#utility-commands)
+- [Meta commands](#meta-commands)
+
+---
+
+## Development commands
+
+### `spin up`
+
+Start all services defined in `docker-compose.yml` + `docker-compose.$SPIN_ENV.yml`.
+
+```bash
+spin up [OPTIONS]
+```
+
+Defaults to `COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml docker compose up`.
+
+Spin-specific options:
+- `--skip-pull` — Do not automatically pull images
+- `--force-pull` — Pull images regardless of cache
+
+All [`docker compose up`](https://docs.docker.com/compose/reference/up/) options are supported.
+
+Override environment: `SPIN_ENV=testing spin up` uses `docker-compose.testing.yml`.
+
+Tip: Use `spin up --build` when compose files have `build:` directives.
+
+### `spin down`
+
+Stop and remove containers, networks, volumes, and images created by `up`.
+
+```bash
+spin down [OPTIONS]
+```
+
+Wraps `docker compose down`.
+
+### `spin stop`
+
+Send `SIGTERM` to all containers (graceful stop).
+
+```bash
+spin stop
+```
+
+### `spin build`
+
+Build images from compose files without starting containers.
+
+```bash
+spin build [OPTIONS]
+```
+
+Wraps [`docker compose build`](https://docs.docker.com/compose/reference/build/).
+
+### `spin run`
+
+Run a one-off command in a **new** container, then exit. Requires a Docker Compose file.
+
+```bash
+spin run [OPTIONS] SERVICE COMMAND
+```
+
+Examples:
+
+```bash
+spin run php composer install
+spin run php php artisan migrate
+spin run node yarn install
+```
+
+Spin-specific options:
+- `--skip-pull` — Do not automatically pull images
+- `--force-pull` — Pull images regardless of cache
+
+The container is automatically removed after the command completes. Container dependencies are not started.
+
+### `spin exec`
+
+Run a command in a **currently running** container (requires `spin up` to be active).
+
+```bash
+spin exec [OPTIONS] SERVICE COMMAND
+```
+
+Example:
+
+```bash
+spin exec php php artisan tinker
+```
+
+### `spin logs`
+
+View container logs.
+
+```bash
+spin logs [OPTIONS]
+```
+
+Wraps [`docker compose logs`](https://docs.docker.com/compose/reference/logs/). Use `-f` to follow.
+
+### `spin ps`
+
+List containers for the compose project.
+
+```bash
+spin ps [OPTIONS]
+```
+
+Wraps [`docker compose ps`](https://docs.docker.com/reference/cli/docker/compose/ps/).
+
+### `spin pull`
+
+Pull images defined in compose files.
+
+```bash
+spin pull [OPTIONS]
+```
+
+Wraps [`docker compose pull`](https://docs.docker.com/engine/reference/commandline/compose_pull/).
+
+### `spin kill`
+
+Send `SIGKILL` to all containers (immediate stop).
+
+```bash
+spin kill
+```
+
+---
+
+## Project setup commands
+
+### `spin new`
+
+Create a new project from a template.
+
+```bash
+spin new <template-name> [project-name]
+```
+
+Available templates: `laravel`, `nuxt`, or any GitHub repo URL.
+
+Example:
+
+```bash
+spin new laravel my-app
+```
+
+### `spin init`
+
+Initialize Spin on an existing project. Creates Docker Compose files, Dockerfile, and `.infrastructure/` folder.
+
+```bash
+spin init [--skip-dependency-install]
+```
+
+Project types: `laravel`, `laravel-pro`, `nuxt`.
+
+### `spin latest`
+
+Run a one-off container with the latest PHP or Node image (works outside project directories).
+
+```bash
+spin latest SERVICE COMMAND
+```
+
+Services: `php`, `node`.
+
+Example:
+
+```bash
+spin latest php php my_script.php
+```
+
+---
+
+## Deployment and infrastructure commands
+
+### `spin deploy`
+
+Deploy application to a provisioned server. Builds locally, pushes via SSH tunnel, deploys to Docker Swarm.
+
+```bash
+spin deploy [OPTIONS] <environment>
+```
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--compose-file` | `-c` | `docker-compose.yml,docker-compose.prod.yml` | Compose files to use |
+| `--port` | `-p` | `22` | SSH port |
+| `--user` | `-u` | Current user (`whoami`) | SSH user |
+| `--upgrade` | `-U` | `false` | Force upgrade Ansible collection |
+
+Environment variables: `SPIN_BUILD_PLATFORM` (default `linux/amd64`), `SPIN_BUILD_TAGS`, `SPIN_REGISTRY_PORT` (default `5080`), `SPIN_PROJECT_NAME`.
+
+Per-environment `.env` files: Create `.env.production`, `.env.staging`, etc. Laravel automatically uses the correct file based on `APP_ENV`.
+
+### `spin provision`
+
+Provision and configure servers from `.spin.yml`.
+
+```bash
+spin provision [environment] [OPTIONS]
+```
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--host` | `-h` | (none) | Target hostname or group |
+| `--port` | `-p` | `22` | SSH port |
+| `--user` | `-u` | Current user | SSH user |
+| `--upgrade` | `-U` | Daily check | Force upgrade Ansible collection |
+
+For non-provider servers, use `-u root` on first run.
+
+### `spin maintain`
+
+Apply OS and Docker updates on servers.
+
+```bash
+spin maintain [environment] [OPTIONS]
+```
+
+Same options as `spin provision`.
+
+### `spin configure`
+
+Configure deployment settings (GitHub Actions integration).
+
+```bash
+spin configure gha <environment>
+```
+
+Sets up GitHub Actions secrets and SSH keys for automated deployments.
+
+---
+
+## Utility commands
+
+### `spin base64`
+
+Cross-platform base64 encoding/decoding (normalizes MacOS vs Linux syntax).
+
+```bash
+spin base64 -e <file>    # Encode
+spin base64 -d <file>    # Decode
+```
+
+### `spin mkpasswd`
+
+Generate password hashes (runs `mkpasswd` via Docker).
+
+```bash
+spin mkpasswd [password]
+```
+
+Omit the password for interactive mode.
+
+### `spin vault`
+
+Encrypt/decrypt files with Ansible Vault.
+
+```bash
+spin vault <action> [file]
+```
+
+Actions: `edit`, `encrypt`, `decrypt`, `view`, `create`, `encrypt_string`, `rekey`.
+
+### `spin gh`
+
+Run GitHub CLI via Docker (`serversideup/github-cli`).
+
+```bash
+spin gh [OPTIONS] <command>
+```
+
+### `spin prune`
+
+Clear local Docker and Spin caches. Runs `docker system prune --all`.
+
+```bash
+spin prune [OPTIONS]
+```
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--force` | `-f` | Skip confirmation |
+
+Add `--volumes` to also remove volumes.
+
+---
+
+## Meta commands
+
+### `spin help`
+
+Display a link to the Spin documentation.
+
+```bash
+spin help
+```
+
+### `spin version`
+
+Print the installed Spin version.
+
+```bash
+spin version
+```
+
+### `spin debug`
+
+Display environment and configuration info for bug reports.
+
+```bash
+spin debug
+```
+
+### `spin update`
+
+Update Spin to the latest version (system installs only, not Composer/Yarn installs).
+
+```bash
+spin update
+```

--- a/resources/boost/skills/spin-laravel-development/DEPLOYMENT.md
+++ b/resources/boost/skills/spin-laravel-development/DEPLOYMENT.md
@@ -1,0 +1,205 @@
+# Deployment
+
+## Table of contents
+
+- [Choosing a strategy](#choosing-a-strategy)
+- [spin deploy](#spin-deploy)
+- [GitHub Actions](#github-actions)
+- [Production compose patterns](#production-compose-patterns)
+- [Per-environment env files](#per-environment-env-files)
+- [spin.yml server configuration](#spinyml-server-configuration)
+
+---
+
+## Choosing a strategy
+
+| Strategy | Best for | Complexity |
+|----------|----------|------------|
+| `spin deploy` | Solo developers, simple deployments | Low |
+| GitHub Actions | Teams, CI/CD pipelines | Medium |
+
+Both strategies deploy to Docker Swarm with zero-downtime updates.
+
+## spin deploy
+
+Builds locally, pushes via SSH tunnel to the server, deploys as a Docker Swarm stack — all in one command:
+
+```bash
+spin deploy production
+spin deploy staging
+```
+
+### How it works
+
+1. Loads `.env` (or `.env.<environment>`)
+2. Finds Dockerfiles and builds images with `docker buildx`
+3. Starts a temporary local Docker registry
+4. Pushes built images to the local registry
+5. Opens an SSH tunnel to the server
+6. Server pulls images through the tunnel
+7. Deploys the Docker Swarm stack
+8. Cleans up registry and tunnel
+
+### Prerequisites
+
+- Server provisioned with `spin provision`
+- `.spin.yml` configured with server addresses
+- SSH access to the server
+
+### Options
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--compose-file` | `-c` | `docker-compose.yml,docker-compose.prod.yml` | Compose files |
+| `--port` | `-p` | `22` | SSH port |
+| `--user` | `-u` | Current user | SSH user |
+| `--upgrade` | `-U` | `false` | Force Ansible collection upgrade |
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPIN_BUILD_PLATFORM` | `linux/amd64` | Build platform |
+| `SPIN_BUILD_TAGS` | `latest` | Image tags |
+| `SPIN_REGISTRY_PORT` | `5080` | Local registry port |
+| `SPIN_PROJECT_NAME` | `spin` | Project name for the stack |
+| `SPIN_TRAEFIK_CONFIG_FILE` | `.infrastructure/conf/traefik/prod/traefik.yml` | Traefik config path |
+
+### Compose variables available after deploy
+
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `SPIN_IMAGE_DOCKERFILE` | `localhost:5080/dockerfile:latest` | Built image reference |
+| `SPIN_MD5_HASH_*` | `abcdef123456` | MD5 of config files (for Swarm config rotation) |
+| `SPIN_DEPLOYMENT_ENVIRONMENT` | `production` | Target environment name |
+| `SPIN_APP_DOMAIN` | `example.com` | Extracted from `APP_URL` in `.env` |
+
+## GitHub Actions
+
+Open source actions for automated CI/CD:
+
+- [**docker-build-action**](https://github.com/marketplace/actions/docker-build-action) — Build and publish Docker images
+- [**docker-swarm-deploy-github-action**](https://github.com/marketplace/actions/docker-swarm-deploy-github-action) — Deploy to Docker Swarm
+
+### Setup with Spin
+
+```bash
+spin configure gha <environment>
+```
+
+This configures GitHub repository secrets and SSH keys for deployment.
+
+### Security considerations
+
+- Deployment SSH keys are stored in GitHub Actions secrets
+- Consider self-hosted runners for tighter security
+- Consider IP-restricted SSH access for production servers
+
+### Zero-downtime requirements
+
+For zero-downtime deployments to work:
+- Traefik (or another reverse proxy) must be configured
+- Container health checks must be defined
+- Docker Swarm update configs must use `order: start-first`
+- Services must handle graceful shutdown
+
+## Production compose patterns
+
+Key settings for `docker-compose.prod.yml`:
+
+```yaml
+services:
+  php:
+    image: ${SPIN_IMAGE_DOCKERFILE}
+    environment:
+      PHP_OPCACHE_ENABLE: "1"
+      AUTORUN_ENABLED: "true"
+      SSL_MODE: full
+      HEALTHCHECK_PATH: "/up"
+    deploy:
+      replicas: 1
+      update_config:
+        failure_action: rollback
+        parallelism: 1
+        delay: 5s
+        order: start-first
+      rollback_config:
+        parallelism: 0
+        order: stop-first
+      restart_policy:
+        condition: any
+        delay: 10s
+        max_attempts: 3
+        window: 120s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.app.rule=Host(`${SPIN_APP_DOMAIN}`)"
+      - "traefik.http.routers.app.entrypoints=websecure"
+      - "traefik.http.routers.app.tls=true"
+      - "traefik.http.routers.app.tls.certresolver=letsencryptresolver"
+      - "traefik.http.services.app.loadbalancer.server.port=8443"
+      - "traefik.http.services.app.loadbalancer.server.scheme=https"
+      - "traefik.http.services.app.loadbalancer.healthcheck.path=/up"
+      - "traefik.http.services.app.loadbalancer.healthcheck.interval=30s"
+      - "traefik.http.services.app.loadbalancer.healthcheck.scheme=http"
+
+  traefik:
+    configs:
+      - source: traefik
+        target: /etc/traefik/traefik.yml
+
+configs:
+  traefik:
+    name: "traefik-${SPIN_MD5_HASH_TRAEFIK_YML}.yml"
+    file: ./.infrastructure/conf/traefik/prod/traefik.yml
+
+volumes:
+  storage_private:
+  storage_public:
+  storage_sessions:
+  storage_logs:
+  database_sqlite:
+
+networks:
+  web-public:
+```
+
+## Per-environment env files
+
+Create separate `.env` files for each deployment environment:
+
+```
+.env                # Local development (default)
+.env.production     # Production settings
+.env.staging        # Staging settings
+```
+
+`spin deploy production` sets `APP_ENV=production`, and Laravel automatically loads `.env.production`.
+
+Add `.env.*` to `.gitignore`.
+
+## .spin.yml server configuration
+
+The `.spin.yml` file defines your server inventory. Basic structure:
+
+```yaml
+users:
+  - username: alice
+    name: Alice
+    groups: ["sudo"]
+    authorized_ssh_keys:
+      - "ssh-ed25519 AAAA... alice@example.com"
+
+servers:
+  - server_name: server01
+    environment: production
+    address: 203.0.113.10
+
+environments:
+  production:
+    docker_user: alice
+```
+
+For provider-managed servers (Hetzner, DigitalOcean, Vultr), Spin creates the server and fills in the `address` automatically.
+
+Encrypt sensitive values with `spin vault encrypt .spin.yml`.

--- a/resources/boost/skills/spin-laravel-development/DOCKER-IMAGES.md
+++ b/resources/boost/skills/spin-laravel-development/DOCKER-IMAGES.md
@@ -1,0 +1,151 @@
+# serversideup/php Docker Images
+
+## Table of contents
+
+- [Image variants](#image-variants)
+- [Tag format](#tag-format)
+- [Key environment variables](#key-environment-variables)
+- [Laravel automations](#laravel-automations)
+- [Health checks](#health-checks)
+- [Adding PHP extensions](#adding-php-extensions)
+- [S6 Overlay](#s6-overlay)
+
+---
+
+## Image variants
+
+| Variant | Process model | Use case |
+|---------|--------------|----------|
+| `fpm-nginx` | NGINX + PHP-FPM (S6 Overlay) | Most Laravel web apps |
+| `fpm-apache` | Apache + PHP-FPM (S6 Overlay) | Apps needing `.htaccess` |
+| `frankenphp` | FrankenPHP/Caddy | Laravel Octane, HTTP/2+3 |
+| `fpm` | PHP-FPM only | Bring your own web server |
+| `cli` | CLI only | Artisan, queue workers, schedulers, CI |
+
+## Tag format
+
+```
+serversideup/php:<php-version>-<variant>[-alpine]
+```
+
+Examples:
+
+```
+serversideup/php:8.5-fpm-nginx
+serversideup/php:8.5-fpm-nginx-alpine
+serversideup/php:8.4-frankenphp
+serversideup/php:8.5-cli
+```
+
+Images are available on Docker Hub and GitHub Packages. Debian by default, Alpine available.
+
+## Key environment variables
+
+### PHP configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PHP_MEMORY_LIMIT` | `256M` | PHP memory limit |
+| `PHP_MAX_EXECUTION_TIME` | `99` | Max execution time (seconds) |
+| `PHP_UPLOAD_MAX_FILE_SIZE` | `256M` | Max upload file size |
+| `PHP_POST_MAX_SIZE` | `256M` | Max POST size |
+| `PHP_OPCACHE_ENABLE` | `0` | Enable OPcache (`1` for production) |
+| `PHP_DATE_TIMEZONE` | `UTC` | PHP timezone |
+
+### Application
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `APP_BASE_DIR` | `/var/www/html` | Application base directory |
+| `LOG_OUTPUT_LEVEL` | `warn` | Container log verbosity (`debug`, `info`, `warn`, `off`) |
+| `DISABLE_DEFAULT_CONFIG` | (unset) | Disable all default configs and automations |
+| `SHOW_WELCOME_MESSAGE` | `true` | Show startup welcome message |
+
+### SSL (fpm-nginx, fpm-apache)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SSL_MODE` | `off` | SSL mode (`off`, `full`) |
+| `SSL_CERTIFICATE_FILE` | (default path) | Path to SSL certificate |
+| `SSL_PRIVATE_KEY_FILE` | (default path) | Path to SSL private key |
+
+### NGINX (fpm-nginx only)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NGINX_WEBROOT` | `/var/www/html/public` | NGINX document root |
+| `NGINX_CLIENT_MAX_BODY_SIZE` | `256M` | Max request body size |
+
+### S6 Overlay (fpm-nginx, fpm-apache only)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `S6_BEHAVIOUR_IF_STAGE2_FAILS` | `2` | `2` = stop container on failure |
+| `S6_CMD_WAIT_FOR_SERVICES_MAXTIME` | (default) | Max wait for services (ms) |
+
+## Laravel automations
+
+All automations require `AUTORUN_ENABLED=true`. Enable in **production only** — set `false` in CI.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTORUN_ENABLED` | `false` | Master switch for all automations |
+| `AUTORUN_LARAVEL_OPTIMIZE` | `true` | Run `php artisan optimize` |
+| `AUTORUN_LARAVEL_CONFIG_CACHE` | `true` | Cache configuration |
+| `AUTORUN_LARAVEL_EVENT_CACHE` | `true` | Cache events |
+| `AUTORUN_LARAVEL_ROUTE_CACHE` | `true` | Cache routes |
+| `AUTORUN_LARAVEL_VIEW_CACHE` | `true` | Cache views |
+| `AUTORUN_LARAVEL_STORAGE_LINK` | `true` | Create storage symlink |
+| `AUTORUN_LARAVEL_MIGRATION` | `true` | Run migrations |
+| `AUTORUN_LARAVEL_MIGRATION_FORCE` | `true` | Use `--force` flag |
+| `AUTORUN_LARAVEL_MIGRATION_ISOLATION` | `false` | Use `--isolated` (needs shared cache driver) |
+| `AUTORUN_LARAVEL_MIGRATION_TIMEOUT` | `30` | Seconds to wait for DB before migrating |
+
+On startup, automations clear config cache, wait for the database (retrying every second up to `MIGRATION_TIMEOUT`), then run migrations and caching. If any step fails, the container does not start.
+
+## Health checks
+
+| Variable | Default | Variants |
+|----------|---------|----------|
+| `HEALTHCHECK_PATH` | `/healthcheck` | fpm-nginx, fpm-apache |
+
+For Laravel, use the built-in health route:
+
+```yaml
+environment:
+  HEALTHCHECK_PATH: "/up"
+```
+
+In production with Traefik, configure both Docker health checks and Traefik health checks:
+
+```yaml
+labels:
+  - "traefik.http.services.app.loadbalancer.healthcheck.path=/up"
+  - "traefik.http.services.app.loadbalancer.healthcheck.interval=30s"
+  - "traefik.http.services.app.loadbalancer.healthcheck.scheme=http"
+```
+
+## Adding PHP extensions
+
+Use `install-php-extensions` in the Dockerfile:
+
+```dockerfile
+FROM serversideup/php:8.5-fpm-nginx-alpine AS base
+USER root
+RUN install-php-extensions bcmath gd intl redis
+```
+
+Always switch to `USER root` before installing, then back to `USER www-data` in subsequent stages.
+
+## S6 Overlay
+
+Used by `fpm-nginx` and `fpm-apache` to run two processes (web server + PHP-FPM) in one container. Handles startup ordering: user setup, Laravel automations, then the main process.
+
+Not used by `frankenphp` (single process) or `cli` (no web server).
+
+## Full documentation
+
+- Docs: <https://serversideup.net/open-source/docker-php/docs>
+- LLM-friendly: <https://serversideup.net/open-source/docker-php/llms.txt>
+- LLM-friendly (full): <https://serversideup.net/open-source/docker-php/llms-full.txt>
+- Complete environment variable reference: <https://serversideup.net/open-source/docker-php/docs/reference/environment-variable-specification>

--- a/resources/boost/skills/spin-laravel-development/LARAVEL-SERVICES.md
+++ b/resources/boost/skills/spin-laravel-development/LARAVEL-SERVICES.md
@@ -1,0 +1,262 @@
+# Laravel Services
+
+Docker Compose service configurations for Laravel with Spin.
+
+## Table of contents
+
+- [Connection pattern](#connection-pattern)
+- [MySQL](#mysql)
+- [PostgreSQL](#postgresql)
+- [MariaDB](#mariadb)
+- [SQLite](#sqlite)
+- [Redis](#redis)
+- [Laravel Queues](#laravel-queues)
+- [Laravel Horizon](#laravel-horizon)
+- [Laravel Reverb](#laravel-reverb)
+- [Laravel Task Scheduler](#laravel-task-scheduler)
+- [Laravel Octane](#laravel-octane)
+- [Vite](#vite)
+- [Mailpit](#mailpit)
+- [Meilisearch](#meilisearch)
+
+---
+
+## Connection pattern
+
+In Docker, services connect via **container name as hostname**:
+
+```env
+DB_HOST=mysql        # NOT localhost, NOT 127.0.0.1
+REDIS_HOST=redis
+MAIL_HOST=mailpit
+```
+
+Avoid special characters in passwords — use long (20+) alphanumeric strings.
+
+Database credentials are only created on **first container initialization**. To reset, remove the volume and re-run `spin up`.
+
+---
+
+## MySQL
+
+`.env` configuration:
+
+```env
+DB_CONNECTION=mysql
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=laraveluser
+DB_PASSWORD=laravelpassword
+```
+
+Exposed on `localhost:3306` in development for GUI database clients.
+
+---
+
+## PostgreSQL
+
+`.env` configuration:
+
+```env
+DB_CONNECTION=pgsql
+DB_HOST=postgres
+DB_PORT=5432
+DB_DATABASE=laravel
+DB_USERNAME=laraveluser
+DB_PASSWORD=laravelpassword
+```
+
+Exposed on `localhost:5432` in development.
+
+---
+
+## MariaDB
+
+Drop-in replacement for MySQL. Uses the same `DB_CONNECTION=mysql`.
+
+```env
+DB_CONNECTION=mysql
+DB_HOST=mariadb
+DB_PORT=3306
+DB_DATABASE=laravel
+DB_USERNAME=laraveluser
+DB_PASSWORD=laravelpassword
+```
+
+---
+
+## SQLite
+
+Spin stores the SQLite database in `.infrastructure/volume_data/sqlite/` to allow volume mounting without overwriting Laravel files.
+
+```env
+DB_CONNECTION=sqlite
+DB_DATABASE=/var/www/html/.infrastructure/volume_data/sqlite/database.sqlite
+```
+
+The path uses the **container path** (`/var/www/html/`), not the host path.
+
+---
+
+## Redis
+
+```env
+REDIS_HOST=redis
+REDIS_PASSWORD=redispassword
+```
+
+Installing Laravel Horizon automatically includes Redis.
+
+---
+
+## Laravel Queues
+
+Dedicated queue worker service. Default command:
+
+```bash
+php artisan queue:work --tries=3
+```
+
+Runs as a separate Docker service alongside the main PHP service.
+
+---
+
+## Laravel Horizon
+
+Dashboard and queue manager for Redis queues. Default command:
+
+```bash
+php artisan horizon
+```
+
+Access the dashboard at `http://<app-url>/horizon`.
+
+Automatically installs Redis when selected.
+
+---
+
+## Laravel Reverb
+
+WebSocket server for real-time features. Default command:
+
+```bash
+php artisan reverb:start
+```
+
+Development URL: `wss://reverb.dev.test`
+
+Production requires a **separate DNS entry** from your app domain. Example: if your app is at `app.example.com`, set up `socket.example.com` pointing to the same server, and configure:
+
+```env
+REVERB_HOST=socket.example.com
+```
+
+---
+
+## Laravel Task Scheduler
+
+Runs scheduled tasks every minute. Default command:
+
+```bash
+php artisan schedule:work
+```
+
+---
+
+## Laravel Octane
+
+High-performance application server using FrankenPHP. Default command:
+
+```bash
+php artisan octane:start --server=frankenphp --port=8080
+```
+
+Considerations when using Octane:
+- The application stays loaded in memory between requests
+- Avoid storing state in global variables
+- Singletons persist between requests
+- Test thoroughly — persistent processes can expose hidden bugs
+
+---
+
+## Vite
+
+Development asset server with HMR over HTTPS.
+
+Development URL: `https://vite.dev.test`
+
+Default `vite.config.js` for Spin:
+
+```js
+import fs from 'fs';
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+
+export default defineConfig({
+    server: {
+        host: '0.0.0.0',
+        hmr: {
+            host: 'vite.dev.test',
+            clientPort: 443,
+        },
+        https: {
+            key: fs.readFileSync('/usr/src/app/.infrastructure/conf/traefik/dev/certificates/local-dev-key.pem'),
+            cert: fs.readFileSync('/usr/src/app/.infrastructure/conf/traefik/dev/certificates/local-dev.pem'),
+        },
+    },
+    plugins: [
+        laravel({
+            input: ['resources/css/app.css', 'resources/js/app.js'],
+            refresh: true,
+        }),
+    ],
+});
+```
+
+Run with: `spin run node yarn dev`
+
+For production HTTPS asset loading, add to `AppServiceProvider::register()`:
+
+```php
+if ($this->app->environment('production') || $this->app->environment('dev')) {
+    URL::forceScheme('https');
+}
+```
+
+---
+
+## Mailpit
+
+Local email testing (development only).
+
+URL: `https://mailpit.dev.test`
+
+```env
+MAIL_MAILER=smtp
+MAIL_HOST=mailpit
+MAIL_PORT=1025
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_ENCRYPTION=
+```
+
+The Mailpit container may take ~15 seconds to start. If you see a 404 immediately after `spin up`, wait and retry.
+
+---
+
+## Meilisearch
+
+Full-text search engine. Integrates with Laravel Scout.
+
+Development UI: `https://meilisearch.dev.test`
+
+```env
+SCOUT_DRIVER=meilisearch
+MEILISEARCH_HOST=http://meilisearch:7700
+MEILISEARCH_KEY=developmentkey1234567890
+```
+
+For production, set a secure key (20+ alphanumeric characters). Avoid running the Meilisearch UI in production unless properly secured.
+
+For additional service configurations and updates, see <https://getspin.pro/docs>.

--- a/resources/boost/skills/spin-laravel-development/SKILL.md
+++ b/resources/boost/skills/spin-laravel-development/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: spin-laravel-development
+description: "Develops and deploys Laravel applications using Spin and serversideup/php Docker images. Covers Docker Compose configuration, development environment setup, container commands, Laravel service configuration (databases, queues, Horizon, Reverb), server provisioning, and deployment workflows. Use when working with Spin, Docker Compose files, serversideup/php images, spin commands, configuring Laravel services in Docker, or deploying Laravel apps to production servers."
+---
+
+# Spin Laravel Development
+
+## Table of contents
+
+- [Safety guardrails](#safety-guardrails)
+- [How Spin works](#how-spin-works)
+- [Project structure](#project-structure)
+- [Dockerfile pattern](#dockerfile-pattern)
+- [Development workflow](#development-workflow)
+- [serversideup/php images](#serversideupphp-images)
+- [Laravel services](#laravel-services)
+- [Deployment](#deployment)
+- [Server provisioning](#server-provisioning)
+- [Common pitfalls](#common-pitfalls)
+- [Reference files](#reference-files)
+
+## Safety guardrails
+
+- **NEVER** run commands that could destroy data without explicitly confirming with the user first. This includes `docker system prune`, `docker volume rm`, dropping databases, removing services, or any destructive operation.
+- If Spin fails to run, it is likely because Docker Desktop is not started. Check with `docker info`. If Docker is not running, tell the user to start Docker Desktop and offer to retry before continuing.
+- Always prefer `spin run` over `spin exec` for one-off commands — it is safer because it creates an isolated container.
+
+## How Spin works
+
+Spin wraps Docker Compose and follows its syntax exactly. Any Docker Compose option works with Spin.
+
+The core pattern is **Docker Compose overrides**: a base `docker-compose.yml` is merged with an environment-specific override file. Spin sets `COMPOSE_FILE=docker-compose.yml:docker-compose.$SPIN_ENV.yml` automatically.
+
+**`SPIN_ENV` defaults to `dev`**, so `spin up` is equivalent to:
+
+```bash
+COMPOSE_FILE=docker-compose.yml:docker-compose.dev.yml docker compose up
+```
+
+Override with `SPIN_ENV=testing spin up` to use `docker-compose.testing.yml` instead.
+
+The base file defines shared service structure. Override files add environment-specific settings. Docker merges them intelligently — override values replace or extend base values:
+
+```yaml
+# docker-compose.yml (base — shared across all environments)
+services:
+  traefik:
+    image: traefik:v3.6
+  php:
+    depends_on:
+      - traefik
+```
+
+```yaml
+# docker-compose.dev.yml (development overrides)
+services:
+  traefik:
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./.infrastructure/conf/traefik/dev/traefik.yml:/traefik.yml:ro
+  php:
+    build:
+      target: development
+      args:
+        USER_ID: ${SPIN_USER_ID}
+        GROUP_ID: ${SPIN_GROUP_ID}
+    volumes:
+      - .:/var/www/html/
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.laravel.rule=HostRegexp(`localhost`)"
+      - "traefik.http.routers.laravel.entrypoints=web"
+      - "traefik.http.services.laravel.loadbalancer.server.port=8080"
+      - "traefik.http.services.laravel.loadbalancer.server.scheme=http"
+  node:
+    image: node:22
+    volumes:
+      - .:/usr/src/app/
+    working_dir: /usr/src/app/
+```
+
+```yaml
+# docker-compose.prod.yml (production overrides — Docker Swarm)
+services:
+  php:
+    image: ${SPIN_IMAGE_DOCKERFILE}
+    environment:
+      AUTORUN_ENABLED: "true"
+      SSL_MODE: full
+    deploy:
+      replicas: 1
+      update_config:
+        failure_action: rollback
+        order: start-first
+    labels:
+      - "traefik.http.routers.my-php-app.rule=Host(`${SPIN_APP_DOMAIN}`)"
+      - "traefik.http.routers.my-php-app.tls.certresolver=letsencryptresolver"
+```
+
+## Project structure
+
+```
+docker-compose.yml              # Base (shared services)
+docker-compose.dev.yml           # Dev overrides (ports, volumes, build target, labels)
+docker-compose.prod.yml          # Prod overrides (Swarm deploy, TLS, health checks)
+Dockerfile                       # Multi-stage: base → development → ci → deploy
+.env                             # Read by Docker Compose AND Laravel (dual-use)
+.spin.yml                        # Server inventory for provisioning (optional)
+.infrastructure/
+  conf/
+    traefik/dev/                 # Dev Traefik config + local certs (committed)
+    traefik/prod/                # Prod Traefik config (committed)
+  volume_data/
+    sqlite/                      # SQLite data (gitignored)
+    redis/                       # Redis data (gitignored)
+```
+
+The `.infrastructure/` folder is flexible. `conf/` stores committed configuration. `volume_data/` stores gitignored persistent data for any service. This keeps everything portable — moving the project folder moves all data with it. Check the project's `.gitignore` to determine what is tracked.
+
+## Dockerfile pattern
+
+Multi-stage build using `serversideup/php`:
+
+```dockerfile
+FROM serversideup/php:8.5-fpm-nginx-alpine AS base
+# Uncomment to add PHP extensions:
+# USER root
+# RUN install-php-extensions bcmath gd
+
+FROM base AS development
+ARG USER_ID
+ARG GROUP_ID
+USER root
+RUN docker-php-serversideup-set-id www-data $USER_ID:$GROUP_ID && \
+    docker-php-serversideup-set-file-permissions --owner $USER_ID:$GROUP_ID
+USER www-data
+
+FROM base AS ci
+USER root
+
+FROM base AS deploy
+COPY --chown=www-data:www-data . /var/www/html
+USER www-data
+```
+
+Stages: **base** (production image), **development** (matches host UID/GID via `SPIN_USER_ID`/`SPIN_GROUP_ID`), **ci** (root for CI pipelines), **deploy** (copies app code, sets permissions). The dev compose file targets the `development` stage via `build.target`.
+
+## Development workflow
+
+This is where 90% of Spin usage happens.
+
+### Starting the environment
+
+```bash
+spin up --build    # Recommended: builds and starts all services (foreground)
+spin up -d         # Detached mode (background)
+```
+
+`spin up` runs in the foreground — open a second terminal for other commands. Press `Ctrl+C` to stop.
+
+### Running commands
+
+Syntax: `spin run <service> <command>` — the first argument is the **service name** from `docker-compose.yml`.
+
+```bash
+spin run php composer install
+spin run php php artisan migrate       # First "php" = service, second "php" = binary
+spin run php php artisan make:model Post
+spin run node yarn install
+spin run node yarn dev
+```
+
+**`run` vs `exec`**: Use `spin run` for one-off commands (creates a new container, runs, exits). Use `spin exec` to execute in an already-running container (requires `spin up` to be active). Prefer `spin run` for package installs, migrations, artisan commands.
+
+### Volume mounting
+
+In development, the project directory is mounted at `.:/var/www/html/`, so code changes are reflected instantly — no rebuild needed for code changes.
+
+### When to rebuild
+
+Use `spin up --build` when:
+- Starting a development environment (recommended as default habit)
+- After Dockerfile changes (adding PHP extensions, changing base image)
+- After modifying build-related compose settings
+
+Code-only changes never need a rebuild — volume mounts handle it.
+
+### `.env` dual-use
+
+The `.env` file is read by **both** Docker Compose (for variable substitution like `${SPIN_APP_DOMAIN}`) and Laravel inside the container (since the project is volume-mounted). Example:
+
+```env
+DB_HOST=mysql
+DB_DATABASE=laravel
+SPIN_APP_DOMAIN=laravel.dev.test
+```
+
+### Which compose file to edit
+
+| Change type | File |
+|---|---|
+| Shared service definitions (image, depends_on) | `docker-compose.yml` |
+| Dev-only (ports, volume mounts, build target, Traefik labels) | `docker-compose.dev.yml` |
+| Prod-only (deploy config, Swarm labels, named volumes, TLS) | `docker-compose.prod.yml` |
+
+### Essential commands
+
+| Command | What it does |
+|---------|-------------|
+| `spin up` | Start all services (`docker compose up`) |
+| `spin up --build` | Start and rebuild |
+| `spin down` | Stop and remove containers |
+| `spin run <svc> <cmd>` | One-off command in new container |
+| `spin exec <svc> <cmd>` | Command in running container |
+| `spin logs` | View container logs |
+| `spin ps` | List running containers |
+| `spin build` | Build images without starting |
+
+See [COMMANDS.md](COMMANDS.md) for the complete 26-command reference.
+
+## serversideup/php images
+
+Choose the right variant:
+
+| Variant | Use case |
+|---------|---------|
+| `fpm-nginx` | Most Laravel apps (PHP-FPM + NGINX) |
+| `fpm-apache` | Apps needing `.htaccess` support |
+| `frankenphp` | Laravel Octane with FrankenPHP |
+| `cli` | Artisan commands, queue workers, schedulers |
+
+Tag pattern: `serversideup/php:<php-version>-<variant>[-alpine]`
+Example: `serversideup/php:8.5-fpm-nginx-alpine`
+
+Key environment variables for production:
+
+```yaml
+environment:
+  AUTORUN_ENABLED: "true"           # Enable Laravel automations (migrations, caching)
+  PHP_OPCACHE_ENABLE: "1"           # Enable OPcache
+  SSL_MODE: "full"                  # SSL termination mode
+  HEALTHCHECK_PATH: "/up"           # Laravel's built-in health route
+```
+
+See [DOCKER-IMAGES.md](DOCKER-IMAGES.md) for the full image configuration reference.
+
+## Laravel services
+
+In Docker, services connect via **container name as hostname**. This is critical when generating `.env` files:
+
+```env
+DB_HOST=mysql          # NOT localhost
+REDIS_HOST=redis       # NOT 127.0.0.1
+MAIL_HOST=mailpit
+```
+
+Available services: MySQL, PostgreSQL, MariaDB, SQLite, Redis, Laravel Queues, Horizon, Reverb, Task Scheduler, Octane, Vite, Mailpit, Meilisearch.
+
+Avoid special characters in database passwords — use long (20+) alphanumeric passwords instead.
+
+See [LARAVEL-SERVICES.md](LARAVEL-SERVICES.md) for complete Docker Compose configurations and `.env` settings for each service.
+
+## Deployment
+
+Two strategies:
+
+### `spin deploy` (solo developers)
+
+Builds locally, pushes via SSH tunnel, deploys to Docker Swarm — all in one command:
+
+```bash
+spin deploy production
+```
+
+Requires a provisioned server (`spin provision`) and `.spin.yml` configuration.
+
+### GitHub Actions (teams)
+
+Use open source actions for CI/CD:
+
+- [`serversideup/docker-build-action`](https://github.com/marketplace/actions/docker-build-action) — Build and publish Docker images
+- [`serversideup/docker-swarm-deploy-github-action`](https://github.com/marketplace/actions/docker-swarm-deploy-github-action) — Deploy to Docker Swarm
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for detailed deployment workflows.
+
+## Server provisioning
+
+`spin provision` uses Ansible to configure servers for Docker Swarm:
+
+```bash
+spin provision              # Provision all servers in .spin.yml
+spin provision production   # Provision only production
+```
+
+Server requirements: Ubuntu 22.04+ LTS, x86_64, ports 22/80/443 open, fresh install.
+
+The `.spin.yml` file defines users, providers, servers, and environments. Supports Hetzner, DigitalOcean, Vultr, or any host with SSH access.
+
+## Common pitfalls
+
+| Problem | Solution |
+|---------|---------|
+| `spin up` fails | Check Docker Desktop is running (`docker info`) |
+| Missing compose file error | Ensure both `docker-compose.yml` and `docker-compose.dev.yml` exist |
+| Database connection refused | Use container name as host (`DB_HOST=mysql`), not `localhost` |
+| `SPIN_ENV` not set | Defaults to `dev` — set explicitly for other environments |
+| Wrong image variant | Use `fpm-nginx` for web, `cli` for workers/schedulers |
+| Stale containers | Use `spin up --build` to rebuild |
+| DB password not working | Credentials are only created on first container init — remove volume to reset |
+| Permission errors in container | Check `SPIN_USER_ID`/`SPIN_GROUP_ID` match host user |
+
+See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for remote server debugging and Docker Swarm troubleshooting.
+
+## Reference files
+
+| File | When to load |
+|------|-------------|
+| [COMMANDS.md](COMMANDS.md) | Looking up any Spin command syntax |
+| [DOCKER-IMAGES.md](DOCKER-IMAGES.md) | Configuring serversideup/php images, environment variables, health checks |
+| [DEPLOYMENT.md](DEPLOYMENT.md) | Setting up deployment pipelines or running `spin deploy` |
+| [LARAVEL-SERVICES.md](LARAVEL-SERVICES.md) | Adding databases, queues, Horizon, Reverb, or other Docker services |
+| [TROUBLESHOOTING.md](TROUBLESHOOTING.md) | Debugging issues on remote servers or Docker Swarm |

--- a/resources/boost/skills/spin-laravel-development/SKILL.md
+++ b/resources/boost/skills/spin-laravel-development/SKILL.md
@@ -8,6 +8,7 @@ description: "Develops and deploys Laravel applications using Spin and serversid
 ## Table of contents
 
 - [Safety guardrails](#safety-guardrails)
+- [Laravel Boost MCP](#laravel-boost-mcp)
 - [How Spin works](#how-spin-works)
 - [Project structure](#project-structure)
 - [Dockerfile pattern](#dockerfile-pattern)
@@ -24,6 +25,26 @@ description: "Develops and deploys Laravel applications using Spin and serversid
 - **NEVER** run commands that could destroy data without explicitly confirming with the user first. This includes `docker system prune`, `docker volume rm`, dropping databases, removing services, or any destructive operation.
 - If Spin fails to run, it is likely because Docker Desktop is not started. Check with `docker info`. If Docker is not running, tell the user to start Docker Desktop and offer to retry before continuing.
 - Always prefer `spin run` over `spin exec` for one-off commands — it is safer because it creates an isolated container.
+
+## Laravel Boost MCP
+
+Spin runs PHP inside Docker, not on the host machine. Laravel Boost's MCP server needs a bridge script (`spin-mcp-wait.sh`) that retries until Docker is ready and filters Docker's stdout noise to preserve the JSON-RPC stdio protocol.
+
+The required `.env` configuration:
+
+```env
+BOOST_PHP_EXECUTABLE_PATH="./vendor/bin/spin-mcp-wait.sh ./vendor/bin/spin run -T php php"
+BOOST_COMPOSER_EXECUTABLE_PATH="./vendor/bin/spin run php composer"
+BOOST_NPM_EXECUTABLE_PATH="./vendor/bin/spin run node npm"
+```
+
+**NEVER use `spin-mcp-wait.sh` to run commands.** It is exclusively for MCP server startup. The script will refuse non-MCP invocations with an error. Always use `spin run` or `spin exec` for running commands:
+
+```bash
+spin run php composer install          # Correct
+spin run php php artisan migrate       # Correct
+spin-mcp-wait.sh spin run php ...     # WRONG — never do this
+```
 
 ## How Spin works
 

--- a/resources/boost/skills/spin-laravel-development/TROUBLESHOOTING.md
+++ b/resources/boost/skills/spin-laravel-development/TROUBLESHOOTING.md
@@ -1,0 +1,165 @@
+# Troubleshooting
+
+## Table of contents
+
+- [Local development issues](#local-development-issues)
+- [Docker Swarm debugging](#docker-swarm-debugging)
+- [Exec into running containers](#exec-into-running-containers)
+- [Viewing application logs](#viewing-application-logs)
+- [Health check debugging](#health-check-debugging)
+- [Database connection issues](#database-connection-issues)
+- [Full reset](#full-reset)
+- [Re-provisioning a server](#re-provisioning-a-server)
+
+---
+
+## Local development issues
+
+| Symptom | Cause | Solution |
+|---------|-------|---------|
+| Spin command fails to run | Docker Desktop not started | Run `docker info` to verify. Start Docker Desktop, then retry. |
+| Missing compose file error | No `docker-compose.dev.yml` | Create the file or set `SPIN_ENV` to match your override file name |
+| Port already in use | Another service on port 80/443 | Stop the conflicting service or change ports in `docker-compose.dev.yml` |
+| Permission denied in container | UID/GID mismatch | Check `SPIN_USER_ID` and `SPIN_GROUP_ID` match host user (`id -u`, `id -g`) |
+| Stale containers / old image | Cached Docker layers | Run `spin up --build` to rebuild |
+| Container exits immediately | Error in entrypoint | Check `spin logs` for the error message |
+
+---
+
+## Docker Swarm debugging
+
+These commands run on the **remote server** (SSH in first).
+
+### List all services
+
+```bash
+sudo docker service ls
+```
+
+### View service logs
+
+```bash
+sudo docker service logs <service_name>
+sudo docker service logs -f <service_name>    # Follow logs
+```
+
+### View service task history
+
+Shows why containers failed to start:
+
+```bash
+sudo docker service ps --no-trunc <service_name>
+```
+
+### Inspect service configuration
+
+```bash
+sudo docker service inspect <service_name> --pretty
+```
+
+---
+
+## Exec into running containers
+
+Find the container ID and exec in:
+
+```bash
+sudo docker exec -it $(sudo docker ps --filter "name=<service_name>" --format "{{.ID}}" | head -n 1) sh
+```
+
+Or step by step:
+
+```bash
+sudo docker ps                                # Find the container ID
+sudo docker exec -it <container_id> sh        # Open a shell
+```
+
+---
+
+## Viewing application logs
+
+### Laravel logs inside a container
+
+```bash
+sudo docker exec -it <container_id> sh
+cat storage/logs/laravel.log
+```
+
+### Enable debug-level container output
+
+Set `LOG_OUTPUT_LEVEL=debug` on `serversideup/php` images for verbose container output.
+
+### Application-level logging
+
+For production, use external services (Sentry, GlitchTip, etc.) — container logs are ephemeral and can be lost on restarts.
+
+---
+
+## Health check debugging
+
+Two types of health checks can fail independently:
+
+### Docker health checks
+
+Defined in the Dockerfile or compose file. Docker uses these to determine container health.
+
+### Traefik health checks
+
+Defined in Traefik labels. Traefik uses these to route traffic.
+
+### Common misconfigurations
+
+| Issue | Symptom | Fix |
+|-------|---------|-----|
+| Wrong health check path | Container unhealthy | Set `HEALTHCHECK_PATH="/up"` |
+| Wrong port in Traefik label | 502 Bad Gateway | Match `loadbalancer.server.port` to container's listening port |
+| Wrong scheme | Connection refused | Use `scheme=http` for internal checks, even if TLS terminates at Traefik |
+| Typo in domain variable | Traefik returns 404 | Check `SPIN_APP_DOMAIN` in `.env` matches DNS |
+
+---
+
+## Database connection issues
+
+| Issue | Solution |
+|-------|---------|
+| Connection refused | Use container name as host (`DB_HOST=mysql`), not `localhost` |
+| Access denied | Credentials only created on first `docker volume create`. Remove volume and restart to reset. |
+| Special characters in password | Use long alphanumeric passwords without special characters |
+| DB not ready at startup | `AUTORUN_LARAVEL_MIGRATION_TIMEOUT` controls wait time (default 30s) |
+
+---
+
+## Full reset
+
+Remove everything on a remote server and start fresh:
+
+```bash
+# Remove all services
+sudo docker service rm $(sudo docker service ls -q)
+
+# Remove all containers
+sudo docker rm -f $(sudo docker ps -aq)
+
+# Remove all volumes (DESTRUCTIVE — data loss)
+sudo docker volume rm $(sudo docker volume ls -q)
+
+# Remove all configs
+sudo docker config rm $(sudo docker config ls -q)
+
+# System prune
+sudo docker system prune --all --force
+```
+
+Then redeploy with `spin deploy <environment>`.
+
+---
+
+## Re-provisioning a server
+
+To re-provision a server from scratch:
+
+1. Remove the `address` field from the server in `.spin.yml` (if using a provider, this triggers a new server)
+2. Clear the old SSH key: `ssh-keygen -R <old-ip-address>`
+3. Run `spin provision <environment>`
+
+For existing servers with a new IP, update the `address` in `.spin.yml` and clear the old SSH fingerprint before provisioning.


### PR DESCRIPTION
# What this PR does
<img width="2488" height="1368" alt="laravel-boost" src="https://github.com/user-attachments/assets/6e8adf94-a71c-40fe-bc96-2aedfebf398c" />

Spin now integrates with [Laravel Boost](https://laravel.com/docs/13.x/boost) as a third-party package. When users run `php artisan boost:install`, Boost discovers Spin's guidelines and skills automatically.

**What's included:**

- **Guideline** (`resources/boost/guidelines/`) — Always-loaded overview of Spin, essential commands, Boost MCP setup, and doc links
- **Skill + 5 reference files** (`resources/boost/skills/spin-laravel-development/`) — Docker Compose patterns, all 26 commands, `serversideup/php` image config, 13 Laravel service setups, deployment workflows, and troubleshooting
- **MCP bridge** (`bin/spin-mcp-wait.sh`) — Retries until Docker is ready and filters stdout noise for clean JSON-RPC. Registered as Composer + NPM binary.