### PR TITLE
fix: preserve argv boundaries in spin run and spin exec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,9 +176,10 @@ docker run --rm \
 # lib/actions/example.sh
 #!/usr/bin/env bash
 action_example() {
-    local args=($(filter_out_spin_arguments "$@"))
-    
-    # Implementation here
+    filter_out_spin_arguments "$@"
+    local args=("${SPIN_FILTERED_ARGS[@]}")
+
+    # Implementation here, using "${args[@]}" for the filtered arguments
     echo "Running example command"
 }
 ```
@@ -238,9 +239,11 @@ SPIN_ENV=production spin deploy production
 ### Argument Filtering
 
 ```bash
-# Remove Spin-specific arguments before passing to Docker
-local args=($(filter_out_spin_arguments "$@"))
-$COMPOSE_CMD up ${args[@]}
+# Remove Spin-specific arguments before passing to Docker. The filtered
+# args are returned via the SPIN_FILTERED_ARGS global.
+filter_out_spin_arguments "$@"
+local args=("${SPIN_FILTERED_ARGS[@]}")
+$COMPOSE_CMD up "${args[@]}"
 ```
 
 ### Cache Management

--- a/lib/actions/down.sh
+++ b/lib/actions/down.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 action_down() {
-  local args=($(filter_out_spin_arguments "$@"))
+  filter_out_spin_arguments "$@"
+  local args=("${SPIN_FILTERED_ARGS[@]}")
 
   $COMPOSE_CMD down --remove-orphans "${args[@]}"
 }

--- a/lib/actions/exec.sh
+++ b/lib/actions/exec.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 action_exec(){
-  $COMPOSE_CMD exec $@ 
+  $COMPOSE_CMD exec "$@"
 }

--- a/lib/actions/prune.sh
+++ b/lib/actions/prune.sh
@@ -5,7 +5,7 @@ action_prune(){
     echo "${BOLD}${YELLOW}🚨 You're about to delete some data.${RESET}"
   fi
   
-  docker system prune --all $@
+  docker system prune --all "$@"
   echo "${BOLD}${GREEN}✅ Docker cache cleared.${RESET}"
 
   # Validate SPIN_CACHE_DIR variable is set

--- a/lib/actions/ps.sh
+++ b/lib/actions/ps.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 action_ps(){
-  $COMPOSE_CMD ps $@ 
+  $COMPOSE_CMD ps "$@"
 }

--- a/lib/actions/run.sh
+++ b/lib/actions/run.sh
@@ -2,7 +2,8 @@
 action_run(){
   docker_pull_check "$@"
 
-  local args=($(filter_out_spin_arguments "$@"))
+  filter_out_spin_arguments "$@"
+  local args=("${SPIN_FILTERED_ARGS[@]}")
 
   # Run Docker Compose without dependencies. Ensure automations and S6 logging are disabled
   $COMPOSE_CMD run -e "S6_VERBOSITY=0" -e "SHOW_WELCOME_MESSAGE=false" --remove-orphans --no-deps --rm \

--- a/lib/actions/up.sh
+++ b/lib/actions/up.sh
@@ -2,7 +2,8 @@
 action_up() {
   docker_pull_check "$@"
 
-  local args=($(filter_out_spin_arguments "$@"))
+  filter_out_spin_arguments "$@"
+  local args=("${SPIN_FILTERED_ARGS[@]}")
 
-  $COMPOSE_CMD up --remove-orphans ${args[@]}
+  $COMPOSE_CMD up --remove-orphans "${args[@]}"
 }

--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -459,14 +459,21 @@ export_compose_file_variable(){
   fi
 }
 
+# Filters spin-only flags out of "$@". Returns the remaining arguments via
+# the SPIN_FILTERED_ARGS global. bash can't return arrays through stdout
+# without IFS word-splitting destroying argument boundaries at the call site.
+#
+# Example usage:
+#   filter_out_spin_arguments "$@"
+#   local args=("${SPIN_FILTERED_ARGS[@]}")
+#   $COMPOSE_CMD run ... "${args[@]}"
 filter_out_spin_arguments() {
-    non_docker_args=(
+    SPIN_FILTERED_ARGS=()
+
+    local non_docker_args=(
         "--skip-pull"
         "--force-pull"
     )
-
-    # Declare an array to hold the filtered arguments
-    local filtered_args=()
 
     # Loop through all passed arguments
     for arg in "$@"; do
@@ -479,12 +486,9 @@ filter_out_spin_arguments() {
         done
 
         if ! $is_non_docker_arg; then
-            filtered_args+=("$arg")
+            SPIN_FILTERED_ARGS+=("$arg")
         fi
     done
-
-    # Return the filtered arguments as an array
-    echo "${filtered_args[@]}"
 }
 
 get_ansible_variable(){


### PR DESCRIPTION
## Problem

`spin run` and `spin exec` lose argument boundaries when any argument contains a space or quoted string. Minimal reproduction:

```
spin run --quiet php php -r 'echo "hi";'
# [19-May-2026 20:00:00 UTC] PHP Parse error:  syntax error, unexpected end of file in Command line code on line 1
```

The single-quoted PHP source arrives at the container split into two tokens (`echo` and `"hi";`), so PHP only sees `echo`. Same problem causes any `spin run php php artisan tinker --execute '...'` to fail with similar errors as well. This is especially a big deal with AI agents since Tinker and PHP REPL are important to quickly test/verify certain things.

## Cause

https://github.com/serversideup/spin/blob/e205e410c4ac5bc3944efeb60303672ad299a585/lib/actions/run.sh#L5

`filter_out_spin_arguments` returned its result via `echo "${filtered[@]}"` (space-joined, unquoted), and the caller word-split that back on IFS. Every argument containing whitespace is gone before reaching `docker compose run`.

`lib/actions/exec.sh` had a smaller variant of the same problem: bare `$@` instead of `"$@"`.

## Fix

Use a global-array return-based solution. The same pattern is also used by the existing [`prepare_ansible_run`](https://github.com/serversideup/spin/blob/e205e410c4ac5bc3944efeb60303672ad299a585/lib/functions.sh#L892-L894).

- `filter_out_spin_arguments` now writes to `SPIN_FILTERED_ARGS`
- `run.sh` copies it into a local array to make the usage easier, preserving the previous DX
- `exec.sh` quotes `"$@"`.

Bash 3.2 compatibility is required as noted in AGENTS.md(_I'd recommend creating a contributing.md or similar, or putting the same requirement elsewhere too_). So, I didn't use the nameref(`local -n`) approach, which would've helped avoid introducing global variables, but it only works in Bash 4.3+.